### PR TITLE
Give each surface its own window filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,7 +354,7 @@ change that moves the most criteria.
 | `B04` | partial | `.gitignore` covers build output, `dist/`, and `.release.env`; the generated `AppIcon.icns` is tracked without being marked. |
 | `B09`, `B10` | partial | Visibility and archive state are intentional; there is no `CODEOWNERS`, and the README states "Early" without naming an owner or a maintenance commitment. |
 | `P05`, `P06` | partial | The README covers install, build, and compatibility, but not configuration, security, or support. The community profile sits at 85 %. |
-| `S02` | partial | 66 tests, all pure logic. Everything touching accessibility or the window server is covered only by `openswitchr-diag`, which is manual and absent from CI — as the section above already admits. |
+| `S02` | partial | 88 tests, all pure logic. Everything touching accessibility or the window server is covered only by `openswitchr-diag`, which is manual and absent from CI — as the section above already admits. |
 | `T02` | partial | Nothing validates the markdown. Against the standard's own `.markdownlint.jsonc` this repository reports 26 issues: 24 table-separator spacings, one fenced block without a language, and one duplicate `### Added` heading in `CHANGELOG.md`. All trivial, none currently visible to anyone. |
 
 ### Notable passes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,11 @@ swift test
 # Run from a terminal that holds the Accessibility permission.
 swift run openswitchr-diag --bench --capture
 
+# The filter profiles, applied to the windows actually open. The display scope
+# is the one axis a unit test cannot judge, because a wrong CoreGraphics/AppKit
+# coordinate flip still looks correct on a single display.
+swift run openswitchr-diag --filters
+
 # End-to-end check against the *installed, running* app: synthetic hotkey,
 # overlay latency, real focus change, and two Dock hovers on the same icon.
 swift run openswitchr-diag --probe-app
@@ -349,7 +354,7 @@ change that moves the most criteria.
 | `B04` | partial | `.gitignore` covers build output, `dist/`, and `.release.env`; the generated `AppIcon.icns` is tracked without being marked. |
 | `B09`, `B10` | partial | Visibility and archive state are intentional; there is no `CODEOWNERS`, and the README states "Early" without naming an owner or a maintenance commitment. |
 | `P05`, `P06` | partial | The README covers install, build, and compatibility, but not configuration, security, or support. The community profile sits at 85 %. |
-| `S02` | partial | 42 tests, all pure logic. Everything touching accessibility or the window server is covered only by `openswitchr-diag`, which is manual and absent from CI — as the section above already admits. |
+| `S02` | partial | 66 tests, all pure logic. Everything touching accessibility or the window server is covered only by `openswitchr-diag`, which is manual and absent from CI — as the section above already admits. |
 | `T02` | partial | Nothing validates the markdown. Against the standard's own `.markdownlint.jsonc` this repository reports 26 issues: 24 table-separator spacings, one fenced block without a language, and one duplicate `### Added` heading in `CHANGELOG.md`. All trivial, none currently visible to anyone. |
 
 ### Notable passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Dock preview's hover region now includes the corridor between the Dock
+  icon and the panel. The icon was generous by 4 points and the panel by 6
+  against a gap of 8, so the two overlapped by two points — Dock magnification,
+  a diagonal approach, or simply pausing on the way dropped the pointer into
+  neither and closed the preview while the user was still travelling towards
+  it. The tolerance around both is now 8 points, and the gap between them
+  counts as part of the preview.
 - The switcher opens even when its filter matches nothing, and says so. The
   event tap swallows the hotkey either way, so returning early left `⌘-Tab`
   inert with the system switcher still suppressed — reachable on purpose once a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `WindowFilter`: one pure value type describing which windows a surface wants
+  and in what order, applied by both frontends. Four axes — application scope,
+  minimized handling, display scope, and order — with the switcher's
+  configurable in Settings and the Dock preview's fixed and permissive, because
+  the pointer already chose the application. Defaults reproduce the previous
+  behaviour exactly.
+- `openswitchr-diag --filters`, which applies the profiles to the windows
+  actually open and checks the one axis unit tests cannot judge: that scoping
+  by display leaves no window claimed by no display.
+- Dock previews can switch instantly while one is already open, so the open
+  delay applies to the first preview only and moving along the Dock does not
+  wait again. On by default.
+
 - Shared window foundation used by both frontends: `WindowIndex` (single source
   of truth), `WindowEventBus` (accessibility and `NSWorkspace` notifications,
   no polling), `ThumbnailStore` (ScreenCaptureKit behind an LRU cache with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by display leaves no window claimed by no display.
 - Dock previews can switch instantly while one is already open, so the open
   delay applies to the first preview only and moving along the Dock does not
-  wait again. On by default.
+  wait again. On by default. A hover that resolves before the index has caught
+  up is retried once the rebuild lands, rather than leaving the pointer on an
+  icon with nothing shown.
 
 - Shared window foundation used by both frontends: `WindowIndex` (single source
   of truth), `WindowEventBus` (accessibility and `NSWorkspace` notifications,
@@ -51,6 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   they put destructive targets a few pixels from the one that focuses a window;
   close sits top left and quit top right, in opposite corners rather than side
   by side, because only one of the two can be undone.
+
+### Changed
+
+- The switcher opens even when its filter matches nothing, and says so. The
+  event tap swallows the hotkey either way, so returning early left `⌘-Tab`
+  inert with the system switcher still suppressed — reachable on purpose once a
+  restrictive filter exists, not just on an empty Space.
+- The initial selection is derived from where the current window ended up in the
+  list rather than from a fixed offset of 1, which only ever held while the list
+  was in most-recently-used order and still contained that window.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,13 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The Dock preview's hover region now includes the corridor between the Dock
-  icon and the panel. The icon was generous by 4 points and the panel by 6
-  against a gap of 8, so the two overlapped by two points — Dock magnification,
-  a diagonal approach, or simply pausing on the way dropped the pointer into
-  neither and closed the preview while the user was still travelling towards
-  it. The tolerance around both is now 8 points, and the gap between them
-  counts as part of the preview.
 - The switcher opens even when its filter matches nothing, and says so. The
   event tap swallows the hotkey either way, so returning early left `⌘-Tab`
   inert with the system switcher still suppressed — reachable on purpose once a

--- a/README.md
+++ b/README.md
@@ -218,7 +218,16 @@ ordering and `sort` is free to misbehave with one.
 
 "Most recently opened" is honest about its limits: windows that were already
 open when the app launched are ordered back-to-front from z-order, because
-nothing records when a window that predates the process was opened.
+nothing records when a window that predates the process was opened. The same
+applies after a round trip to another Space: the index keeps bookkeeping only
+for windows it can currently see, so a window that leaves and comes back looks
+newly opened — the same way it already loses its place in the recently-used
+order.
+
+The switcher opens even when the filter matches nothing, and says so. It has to:
+the hotkey is swallowed by the event tap either way, so returning early would
+leave `⌘-Tab` doing nothing at all while the system switcher stayed suppressed,
+with no clue why.
 
 ## Scope: current Space only
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # OpenSwitchr
 
-**One app instead of two.** Dock hover previews and an Alt-Tab style window
+**One app instead of two.** Dock hover previews and a hold-and-Tab window
 switcher, built on a single shared window index.
 
-macOS ships with `⌘-Tab`, which switches *applications*, not *windows*. The two
-best answers to that gap — [DockDoor](https://github.com/ejbills/DockDoor) for
-Dock hover previews and [AltTab](https://github.com/lwouis/alt-tab-macos) for a
-visual switcher — solve two halves of the same problem, and each pays the full
-cost of doing so: enumerating every window, observing every change, and
-capturing every thumbnail. Running both means paying twice.
+macOS ships with `⌘-Tab`, which switches *applications*, not *windows*. The
+usual way to close that gap is to run two separate utilities: one that previews
+an application's windows when you hover its Dock icon, and one that puts a
+visual switcher on screen. They solve two halves of the same problem, and each
+pays the full cost of doing so on its own — enumerating every window, observing
+every change, capturing every thumbnail. Running both means paying twice.
 
 OpenSwitchr pays once. The window index, the event bus, the thumbnail cache, and
 the window actions exist exactly once; the Dock previews and the switcher
@@ -22,8 +22,11 @@ overlay are thin readers on top.
   current Space in most-recently-used order, with live thumbnails. `⌥` and `⌃`
   are available in Settings if you would rather keep the system switcher.
 - **Type to filter** — start typing to narrow by app name or window title.
+- **Choose what the switcher lists** — by application, by display, how
+  minimized windows are treated, and in what order.
 - **Dock hover previews** — hover a Dock icon to see that app's windows; click
-  one to jump straight to it.
+  one to jump straight to it. The open delay applies to the first preview only,
+  so moving along the Dock does not wait again.
 - **Window actions** — focus, minimize, restore, and close from either frontend.
 - **Minimized windows included** — a window in the Dock is still listed, dimmed
   and marked, and activating its tile restores it.
@@ -132,11 +135,19 @@ permission:
 ```bash
 swift run openswitchr-diag                    # window index and AX linking
 swift run openswitchr-diag --bench --capture  # plus timings
+swift run openswitchr-diag --filters          # filter profiles against real windows
 swift run openswitchr-diag --probe-app        # drive the *installed* app
 ```
 
 It reports per-app `CG` / `AX` / `LINKED` counts, which separates "the linking
 heuristic failed" from "this app exposes no accessibility windows at all".
+
+`--filters` exists for the one filter axis unit tests cannot judge. Restricting
+the switcher to one display compares a window frame from CoreGraphics against a
+screen frame AppKit measures in the opposite vertical direction, and a wrong
+flip still looks correct on a single display because the two spaces coincide
+there. The mode applies the scope to every attached display and then asserts
+the thing that actually matters: no window may end up claimed by none of them.
 
 `--probe-app` is the only check that exercises the shipping app rather than the
 core: it posts a synthetic hotkey, measures how long the overlay takes to
@@ -180,6 +191,34 @@ otherwise the tile of an already-closed window would stay on screen. Quitting
 deliberately does *not* prune tiles: `terminate()` is a request, and an app with
 unsaved work may put up a dialog and stay. The panel dismisses instead, which
 also stops it covering that dialog.
+
+## What the switcher shows
+
+Both frontends read the same index, but they do not want the same set, so each
+carries a filter profile. The Dock preview's is fixed and permissive — the
+pointer already picked the application, so any further restriction could only
+hide something you pointed at. The switcher's is yours:
+
+| Axis | Default | Options |
+|---|---|---|
+| Show | All applications | All, only the current application, or everything but the current application |
+| Minimized windows | Show | Show, hide, or show after the rest |
+| Displays | All displays | All, or only the display the switcher appears on |
+| Order | Most recently used | Most recently used, most recently opened, or application then title |
+
+The defaults are exactly what the app did before the setting existed, so
+changing nothing changes nothing.
+
+Two details that are easy to get wrong and are therefore pinned by tests. A
+minimized window is on no display at all, so restricting to one display never
+removes it — otherwise a display setting would quietly delete every window in
+the Dock. And "show after the rest" is a partition applied after ordering, not
+a tie-breaker inside the comparator, because the latter is not a strict weak
+ordering and `sort` is free to misbehave with one.
+
+"Most recently opened" is honest about its limits: windows that were already
+open when the app launched are ordered back-to-front from z-order, because
+nothing records when a window that predates the process was opened.
 
 ## Scope: current Space only
 

--- a/README.md
+++ b/README.md
@@ -151,10 +151,16 @@ the thing that actually matters: no window may end up claimed by none of them.
 
 `--probe-app` is the only check that exercises the shipping app rather than the
 core: it posts a synthetic hotkey, measures how long the overlay takes to
-appear, confirms focus actually moved by reading the CoreGraphics z-order, then
-hovers a Dock icon *twice* and times both previews. The core passing its tests
-says nothing about whether the app wired it up — two release-blocking bugs got
-through exactly that gap.
+appear, **holds the modifier for four seconds to prove the overlay stays**,
+moves the pointer onto the Dock mid-hold to prove a preview appearing beside it
+does not take it away, confirms focus actually moved by reading the
+CoreGraphics z-order, then hovers a Dock icon *twice* and times both previews.
+The core passing its tests says nothing about whether the app wired it up —
+two release-blocking bugs got through exactly that gap.
+
+The two hold checks exist because the probe used to press and release within
+250 ms, so an overlay that appears and then gives up on its own passed every
+check it had.
 
 ## ⌘-Tab
 

--- a/Sources/OpenSwitchr/AppModel.swift
+++ b/Sources/OpenSwitchr/AppModel.swift
@@ -259,6 +259,7 @@ public final class AppModel {
             await self.index.rebuildConcurrently()
             guard !Task.isCancelled else { return }
             self.thumbnails.retain(only: Set(self.index.windows.map(\.id)))
+            self.rebuildFinished()
         }
     }
 
@@ -278,6 +279,20 @@ public final class AppModel {
             guard !Task.isCancelled else { return }
             self.logger.debug("Stale rebuild on show: \(before) -> \(self.index.windows.count) windows")
             self.thumbnails.retain(only: Set(self.index.windows.map(\.id)))
+            self.rebuildFinished()
         }
+    }
+
+    /// The one place a finished rebuild is announced, so every path agrees on
+    /// what happens afterwards.
+    ///
+    /// The switcher check has to happen **here**, at completion, not where the
+    /// rebuild was scheduled: a rebuild is in flight for tens of milliseconds
+    /// and the overlay can open during it, so a guard taken at scheduling time
+    /// says nothing about the state on arrival. A keystroke in one frontend
+    /// must not materialise a panel in the other.
+    private func rebuildFinished() {
+        guard !switcher.isVisible else { return }
+        dockPreview.indexDidRebuild()
     }
 }

--- a/Sources/OpenSwitchr/DockPreviewController.swift
+++ b/Sources/OpenSwitchr/DockPreviewController.swift
@@ -19,6 +19,10 @@ public final class DockPreviewController {
     private var hideTask: Task<Void, Never>?
     private var mouseMonitor: Any?
 
+    /// An item whose hover resolved to no windows, kept so a later index
+    /// rebuild can retry it. See ``indexDidRebuild()``.
+    private var unresolvedItem: DockHoverMonitor.DockItem?
+
     public private(set) var isVisible = false
 
     /// Called whenever a hover ends, so the Dock monitor can reset its
@@ -39,6 +43,11 @@ public final class DockPreviewController {
         showTask = nil
 
         guard let item else {
+            // The pointer left the Dock, so a retry armed by an earlier hover
+            // is no longer wanted. `scheduleHide()` cannot do this on our
+            // behalf: it returns early when no panel is visible, which is
+            // exactly the state an unresolved hover leaves behind.
+            unresolvedItem = nil
             scheduleHide()
             return
         }
@@ -69,6 +78,22 @@ public final class DockPreviewController {
         }
     }
 
+    /// Retries a hover that resolved to nothing before the index caught up.
+    ///
+    /// Called after a rebuild. Hovering a Dock icon starts an asynchronous
+    /// rebuild and then resolves the panel's contents; with the instant path
+    /// those two happen in the wrong order, so an application whose window the
+    /// index had not seen yet produced no panel and nothing ever tried again.
+    /// The pointer must still be on the same icon — the user has otherwise
+    /// moved on, and a panel appearing now would be a surprise rather than a
+    /// recovery.
+    public func indexDidRebuild() {
+        guard let item = unresolvedItem else { return }
+        unresolvedItem = nil
+        guard isMouseInside(item) else { return }
+        show(for: item, isRetry: true)
+    }
+
     private func scheduleHide() {
         guard isVisible else { return }
         let delay = preferences.dockHideDelay
@@ -85,12 +110,21 @@ public final class DockPreviewController {
 
     // MARK: - Presentation
 
-    private func show(for item: DockHoverMonitor.DockItem) {
+    private func show(for item: DockHoverMonitor.DockItem, isRetry: Bool = false) {
         let matches = resolveWindows(for: item)
         guard !matches.isEmpty else {
             hide()
+            // Hovering kicks off an index rebuild that does not block, and the
+            // instant path resolves before it lands — so "no windows" may only
+            // mean "not yet". Armed *once*, and only for a first attempt:
+            // a retry that also came up empty means the icon genuinely has
+            // nothing here, and re-arming would make every later rebuild try
+            // again for as long as the pointer sits on it. Set after `hide()`,
+            // which clears it.
+            if !isRetry { unresolvedItem = item }
             return
         }
+        unresolvedItem = nil
 
         currentItem = item
         windows = matches
@@ -279,6 +313,10 @@ public final class DockPreviewController {
 
     private func isMouseInsideCurrentDockItem() -> Bool {
         guard let item = currentItem else { return false }
+        return isMouseInside(item)
+    }
+
+    private func isMouseInside(_ item: DockHoverMonitor.DockItem) -> Bool {
         let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
         let rect = NSRect(
             x: item.frame.origin.x,
@@ -296,6 +334,7 @@ public final class DockPreviewController {
         hideTask?.cancel()
         showTask = nil
         hideTask = nil
+        unresolvedItem = nil
         stopMouseTracking()
         // Fires even when no panel was on screen: hovering an icon without
         // windows also ends a hover, and the monitor must forget it either way.

--- a/Sources/OpenSwitchr/DockPreviewController.swift
+++ b/Sources/OpenSwitchr/DockPreviewController.swift
@@ -101,11 +101,10 @@ public final class DockPreviewController {
         hideTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled, let self else { return }
-        // Keep the panel open while the pointer is anywhere in the hover
-        // region, so the user can actually travel from the Dock icon onto
-        // a preview tile without the panel closing on the way.
-        if self.isMouseInHoverRegion() { return }
-        self.hide()
+            // Keep the panel open while the pointer is inside it, so the user
+            // can actually move from the Dock icon onto a preview tile.
+            if self.isMouseInsidePanel() { return }
+            self.hide()
         }
     }
 
@@ -284,7 +283,7 @@ public final class DockPreviewController {
         mouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved]) { _ in
             MainActor.assumeIsolated { [weak self] in
                 guard let self, self.isVisible else { return }
-                if !self.isMouseInHoverRegion() {
+                if !self.isMouseInsidePanel() && !self.isMouseInsideCurrentDockItem() {
                     self.scheduleHide()
                 }
             }
@@ -299,47 +298,25 @@ public final class DockPreviewController {
     }
 
     private func isMouseInsidePanel() -> Bool {
-        panel.frame.insetBy(dx: -Self.hoverSlack, dy: -Self.hoverSlack).contains(NSEvent.mouseLocation)
+        panel.frame.insetBy(dx: -6, dy: -6).contains(NSEvent.mouseLocation)
+    }
+
+    private func isMouseInsideCurrentDockItem() -> Bool {
+        guard let item = currentItem else { return false }
+        return isMouseInside(item)
     }
 
     private func isMouseInside(_ item: DockHoverMonitor.DockItem) -> Bool {
-        Self.screenRect(of: item).insetBy(dx: -Self.hoverSlack, dy: -Self.hoverSlack)
-            .contains(NSEvent.mouseLocation)
-    }
-
-    /// How far outside a rectangle still counts as being on it.
-    private static let hoverSlack: CGFloat = 8
-
-    /// Everything that should keep the panel alive: the Dock item, the panel,
-    /// and the corridor between them.
-    ///
-    /// Testing the two rectangles separately leaves a dead strip in the gap.
-    /// The icon was generous by 4 points and the panel by 6 against a gap of 8,
-    /// so the two regions overlapped by two points — and Dock magnification, a
-    /// diagonal approach, or simply pausing on the way was enough to drop the
-    /// pointer into neither and start the hide while the user was still
-    /// travelling towards the panel. The union of the two is the region the
-    /// user actually perceives as "the preview", and leaving it sideways or
-    /// backwards still ends the hover.
-    private func isMouseInHoverRegion() -> Bool {
-        let mouse = NSEvent.mouseLocation
-        if isMouseInsidePanel() { return true }
-        guard let item = currentItem else { return false }
-
-        let itemRect = Self.screenRect(of: item)
-        if itemRect.insetBy(dx: -Self.hoverSlack, dy: -Self.hoverSlack).contains(mouse) { return true }
-        guard isVisible else { return false }
-
-        return itemRect.union(panel.frame)
-            .insetBy(dx: -Self.hoverSlack, dy: -Self.hoverSlack)
-            .contains(mouse)
+        Self.screenRect(of: item).insetBy(dx: -4, dy: -4).contains(NSEvent.mouseLocation)
     }
 
     /// A Dock item's frame in AppKit screen coordinates.
     ///
     /// Accessibility reports it with the origin at the top-left of the primary
     /// display and y growing downwards; AppKit windows use a bottom-left
-    /// origin.
+    /// origin. Kept in one place because both the placement maths and the
+    /// hover test need it, and two copies of a coordinate flip is how they
+    /// stop agreeing.
     private static func screenRect(of item: DockHoverMonitor.DockItem) -> NSRect {
         let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
         return NSRect(

--- a/Sources/OpenSwitchr/DockPreviewController.swift
+++ b/Sources/OpenSwitchr/DockPreviewController.swift
@@ -48,7 +48,20 @@ public final class DockPreviewController {
 
         guard item != currentItem || !isVisible else { return }
 
-        let delay = preferences.dockHoverDelay
+        // Once a preview is on screen the user has already declared intent, so
+        // moving along the Dock switches without waiting again. `isVisible` is
+        // still true while a hide has merely been scheduled, which is
+        // deliberate: that is exactly the moment a fast pointer is crossing the
+        // gap between two icons.
+        let delay = preferences.dockHoverInstantSwitch && isVisible ? 0 : preferences.dockHoverDelay
+
+        // Showing straight away rather than sleeping for zero: the point of
+        // this path is that nothing is scheduled at all.
+        guard delay > 0 else {
+            show(for: item)
+            return
+        }
+
         showTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled, let self else { return }
@@ -225,12 +238,16 @@ public final class DockPreviewController {
     }
 
     private func resolveWindows(for item: DockHoverMonitor.DockItem) -> [WindowInfo] {
-        if let bundleID = item.bundleID {
-            let matches = index.windows(forBundleID: bundleID)
-            if !matches.isEmpty { return matches }
+        var matches = item.bundleID.map { index.windows(forBundleID: $0) } ?? []
+        if matches.isEmpty, !item.title.isEmpty {
+            matches = index.windows.filter { $0.appName == item.title }
         }
-        guard !item.title.isEmpty else { return [] }
-        return index.windows.filter { $0.appName == item.title }
+        guard !matches.isEmpty else { return [] }
+
+        // This surface has a profile too, even though it is the permissive one.
+        // Going through it keeps the claim that both frontends are filtered the
+        // same way true in code rather than only in the README.
+        return WindowFilter.dockPreview.apply(to: matches)
     }
 
     // MARK: - Mouse tracking

--- a/Sources/OpenSwitchr/DockPreviewController.swift
+++ b/Sources/OpenSwitchr/DockPreviewController.swift
@@ -101,10 +101,11 @@ public final class DockPreviewController {
         hideTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled, let self else { return }
-            // Keep the panel open while the pointer is inside it, so the user
-            // can actually move from the Dock icon onto a preview tile.
-            if self.isMouseInsidePanel() { return }
-            self.hide()
+        // Keep the panel open while the pointer is anywhere in the hover
+        // region, so the user can actually travel from the Dock icon onto
+        // a preview tile without the panel closing on the way.
+        if self.isMouseInHoverRegion() { return }
+        self.hide()
         }
     }
 
@@ -229,18 +230,8 @@ public final class DockPreviewController {
     }
 
     /// Places the panel next to the Dock item, on whichever edge the Dock is.
-    ///
-    /// Accessibility reports frames with the origin at the top-left of the
-    /// primary display, while AppKit windows use a bottom-left origin, so the
-    /// vertical axis has to be flipped.
     private func panelOrigin(for item: DockHoverMonitor.DockItem, size: NSSize) -> NSPoint {
-        let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
-        let itemRect = NSRect(
-            x: item.frame.origin.x,
-            y: primaryHeight - item.frame.origin.y - item.frame.height,
-            width: item.frame.width,
-            height: item.frame.height
-        )
+        let itemRect = Self.screenRect(of: item)
 
         let screen = NSScreen.screens.first { $0.frame.intersects(itemRect) } ?? NSScreen.main
         let visible = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
@@ -293,7 +284,7 @@ public final class DockPreviewController {
         mouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved]) { _ in
             MainActor.assumeIsolated { [weak self] in
                 guard let self, self.isVisible else { return }
-                if !self.isMouseInsidePanel() && !self.isMouseInsideCurrentDockItem() {
+                if !self.isMouseInHoverRegion() {
                     self.scheduleHide()
                 }
             }
@@ -308,23 +299,55 @@ public final class DockPreviewController {
     }
 
     private func isMouseInsidePanel() -> Bool {
-        panel.frame.insetBy(dx: -6, dy: -6).contains(NSEvent.mouseLocation)
-    }
-
-    private func isMouseInsideCurrentDockItem() -> Bool {
-        guard let item = currentItem else { return false }
-        return isMouseInside(item)
+        panel.frame.insetBy(dx: -Self.hoverSlack, dy: -Self.hoverSlack).contains(NSEvent.mouseLocation)
     }
 
     private func isMouseInside(_ item: DockHoverMonitor.DockItem) -> Bool {
+        Self.screenRect(of: item).insetBy(dx: -Self.hoverSlack, dy: -Self.hoverSlack)
+            .contains(NSEvent.mouseLocation)
+    }
+
+    /// How far outside a rectangle still counts as being on it.
+    private static let hoverSlack: CGFloat = 8
+
+    /// Everything that should keep the panel alive: the Dock item, the panel,
+    /// and the corridor between them.
+    ///
+    /// Testing the two rectangles separately leaves a dead strip in the gap.
+    /// The icon was generous by 4 points and the panel by 6 against a gap of 8,
+    /// so the two regions overlapped by two points — and Dock magnification, a
+    /// diagonal approach, or simply pausing on the way was enough to drop the
+    /// pointer into neither and start the hide while the user was still
+    /// travelling towards the panel. The union of the two is the region the
+    /// user actually perceives as "the preview", and leaving it sideways or
+    /// backwards still ends the hover.
+    private func isMouseInHoverRegion() -> Bool {
+        let mouse = NSEvent.mouseLocation
+        if isMouseInsidePanel() { return true }
+        guard let item = currentItem else { return false }
+
+        let itemRect = Self.screenRect(of: item)
+        if itemRect.insetBy(dx: -Self.hoverSlack, dy: -Self.hoverSlack).contains(mouse) { return true }
+        guard isVisible else { return false }
+
+        return itemRect.union(panel.frame)
+            .insetBy(dx: -Self.hoverSlack, dy: -Self.hoverSlack)
+            .contains(mouse)
+    }
+
+    /// A Dock item's frame in AppKit screen coordinates.
+    ///
+    /// Accessibility reports it with the origin at the top-left of the primary
+    /// display and y growing downwards; AppKit windows use a bottom-left
+    /// origin.
+    private static func screenRect(of item: DockHoverMonitor.DockItem) -> NSRect {
         let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
-        let rect = NSRect(
+        return NSRect(
             x: item.frame.origin.x,
             y: primaryHeight - item.frame.origin.y - item.frame.height,
             width: item.frame.width,
             height: item.frame.height
         )
-        return rect.insetBy(dx: -4, dy: -4).contains(NSEvent.mouseLocation)
     }
 
     // MARK: - Teardown

--- a/Sources/OpenSwitchr/PreferencesStore.swift
+++ b/Sources/OpenSwitchr/PreferencesStore.swift
@@ -30,14 +30,14 @@ public final class PreferencesStore {
 
     /// The default for anything added here lives exactly once, because a
     /// registered default and the fallback used when a stored value no longer
-    /// parses are two places for the same number, and they have drifted apart
+    /// parses are two spellings of the same value, and they have drifted apart
     /// in this file's history before.
     private enum Default {
         static let dockHoverInstantSwitch = true
-        static let applicationScope = WindowFilter.ApplicationScope.all
-        static let minimizedPolicy = WindowFilter.MinimizedPolicy.show
-        static let screenScope = WindowFilter.ScreenScope.allScreens
-        static let order = WindowFilter.Order.recentlyUsed
+
+        /// Derived rather than restated: `WindowFilter.switcherDefault` is the
+        /// one place the switcher's starting profile is written down.
+        static let filter = WindowFilter.switcherDefault
     }
 
     // Every preference is a *stored* property that writes through to
@@ -138,10 +138,10 @@ public final class PreferencesStore {
             Key.thumbnailRefreshRate: ThumbnailRefreshRate.default.rawValue,
             Key.tileWidth: 200.0,
             Key.showCloseButton: false,
-            Key.switcherApplicationScope: Default.applicationScope.rawValue,
-            Key.switcherMinimizedPolicy: Default.minimizedPolicy.rawValue,
-            Key.switcherScreenScope: Default.screenScope.rawValue,
-            Key.switcherOrder: Default.order.rawValue
+            Key.switcherApplicationScope: Default.filter.applications.rawValue,
+            Key.switcherMinimizedPolicy: Default.filter.minimized.rawValue,
+            Key.switcherScreenScope: Default.filter.screens.rawValue,
+            Key.switcherOrder: Default.filter.order.rawValue
         ])
 
         // An unknown stored modifier means the value was removed from the app,
@@ -166,16 +166,16 @@ public final class PreferencesStore {
         // registered default rather than leaving the switcher without a filter.
         switcherApplicationScope = WindowFilter.ApplicationScope(
             rawValue: defaults.string(forKey: Key.switcherApplicationScope) ?? ""
-        ) ?? Default.applicationScope
+        ) ?? Default.filter.applications
         switcherMinimizedPolicy = WindowFilter.MinimizedPolicy(
             rawValue: defaults.string(forKey: Key.switcherMinimizedPolicy) ?? ""
-        ) ?? Default.minimizedPolicy
+        ) ?? Default.filter.minimized
         switcherScreenScope = WindowFilter.ScreenScope(
             rawValue: defaults.string(forKey: Key.switcherScreenScope) ?? ""
-        ) ?? Default.screenScope
+        ) ?? Default.filter.screens
         switcherOrder = WindowFilter.Order(
             rawValue: defaults.string(forKey: Key.switcherOrder) ?? ""
-        ) ?? Default.order
+        ) ?? Default.filter.order
 
         launchAtLogin = SMAppService.mainApp.status == .enabled
     }

--- a/Sources/OpenSwitchr/PreferencesStore.swift
+++ b/Sources/OpenSwitchr/PreferencesStore.swift
@@ -19,9 +19,26 @@ public final class PreferencesStore {
         static let tileWidth = "tileWidth"
         static let showCloseButton = "showCloseButton"
         static let launchAtLogin = "launchAtLogin"
+        static let dockHoverInstantSwitch = "dockHoverInstantSwitch"
+        static let switcherApplicationScope = "switcherApplicationScope"
+        static let switcherMinimizedPolicy = "switcherMinimizedPolicy"
+        static let switcherScreenScope = "switcherScreenScope"
+        static let switcherOrder = "switcherOrder"
     }
 
     private let defaults: UserDefaults
+
+    /// The default for anything added here lives exactly once, because a
+    /// registered default and the fallback used when a stored value no longer
+    /// parses are two places for the same number, and they have drifted apart
+    /// in this file's history before.
+    private enum Default {
+        static let dockHoverInstantSwitch = true
+        static let applicationScope = WindowFilter.ApplicationScope.all
+        static let minimizedPolicy = WindowFilter.MinimizedPolicy.show
+        static let screenScope = WindowFilter.ScreenScope.allScreens
+        static let order = WindowFilter.Order.recentlyUsed
+    }
 
     // Every preference is a *stored* property that writes through to
     // UserDefaults on change. The @Observable macro only tracks stored
@@ -47,6 +64,46 @@ public final class PreferencesStore {
 
     public var dockHideDelay: TimeInterval {
         didSet { defaults.set(dockHideDelay, forKey: Key.dockHideDelay) }
+    }
+
+    /// Whether the hover delay applies only to the first preview.
+    ///
+    /// The delay exists so that sweeping across the Dock on the way somewhere
+    /// else does not fire a panel. Once one is open the user has already said
+    /// what they want, and waiting again for every icon they move onto reads as
+    /// the app lagging.
+    public var dockHoverInstantSwitch: Bool {
+        didSet { defaults.set(dockHoverInstantSwitch, forKey: Key.dockHoverInstantSwitch) }
+    }
+
+    // The switcher's filter profile. The Dock preview does not get one: it is
+    // already scoped to the application under the pointer, so every further
+    // restriction could only hide windows the user pointed at.
+
+    public var switcherApplicationScope: WindowFilter.ApplicationScope {
+        didSet { defaults.set(switcherApplicationScope.rawValue, forKey: Key.switcherApplicationScope) }
+    }
+
+    public var switcherMinimizedPolicy: WindowFilter.MinimizedPolicy {
+        didSet { defaults.set(switcherMinimizedPolicy.rawValue, forKey: Key.switcherMinimizedPolicy) }
+    }
+
+    public var switcherScreenScope: WindowFilter.ScreenScope {
+        didSet { defaults.set(switcherScreenScope.rawValue, forKey: Key.switcherScreenScope) }
+    }
+
+    public var switcherOrder: WindowFilter.Order {
+        didSet { defaults.set(switcherOrder.rawValue, forKey: Key.switcherOrder) }
+    }
+
+    /// The four axes as the one value the switcher actually applies.
+    public var switcherFilter: WindowFilter {
+        WindowFilter(
+            applications: switcherApplicationScope,
+            minimized: switcherMinimizedPolicy,
+            screens: switcherScreenScope,
+            order: switcherOrder
+        )
     }
 
     public var thumbnailBudgetMB: Int {
@@ -76,10 +133,15 @@ public final class PreferencesStore {
             Key.dockHoverEnabled: true,
             Key.dockHoverDelay: 0.18,
             Key.dockHideDelay: 0.25,
+            Key.dockHoverInstantSwitch: Default.dockHoverInstantSwitch,
             Key.thumbnailBudgetMB: 96,
             Key.thumbnailRefreshRate: ThumbnailRefreshRate.default.rawValue,
             Key.tileWidth: 200.0,
-            Key.showCloseButton: false
+            Key.showCloseButton: false,
+            Key.switcherApplicationScope: Default.applicationScope.rawValue,
+            Key.switcherMinimizedPolicy: Default.minimizedPolicy.rawValue,
+            Key.switcherScreenScope: Default.screenScope.rawValue,
+            Key.switcherOrder: Default.order.rawValue
         ])
 
         // An unknown stored modifier means the value was removed from the app,
@@ -91,12 +153,30 @@ public final class PreferencesStore {
         dockHoverEnabled = defaults.bool(forKey: Key.dockHoverEnabled)
         dockHoverDelay = defaults.double(forKey: Key.dockHoverDelay)
         dockHideDelay = defaults.double(forKey: Key.dockHideDelay)
+        dockHoverInstantSwitch = defaults.bool(forKey: Key.dockHoverInstantSwitch)
         thumbnailBudgetMB = defaults.integer(forKey: Key.thumbnailBudgetMB)
         thumbnailRefreshRate = ThumbnailRefreshRate(
             rawValue: defaults.string(forKey: Key.thumbnailRefreshRate) ?? ""
         ) ?? .default
         tileWidth = defaults.double(forKey: Key.tileWidth)
         showCloseButton = defaults.bool(forKey: Key.showCloseButton)
+
+        // Same fallback rule as the hold modifier: a stored value the app no
+        // longer recognises means the case was removed, so it reverts to the
+        // registered default rather than leaving the switcher without a filter.
+        switcherApplicationScope = WindowFilter.ApplicationScope(
+            rawValue: defaults.string(forKey: Key.switcherApplicationScope) ?? ""
+        ) ?? Default.applicationScope
+        switcherMinimizedPolicy = WindowFilter.MinimizedPolicy(
+            rawValue: defaults.string(forKey: Key.switcherMinimizedPolicy) ?? ""
+        ) ?? Default.minimizedPolicy
+        switcherScreenScope = WindowFilter.ScreenScope(
+            rawValue: defaults.string(forKey: Key.switcherScreenScope) ?? ""
+        ) ?? Default.screenScope
+        switcherOrder = WindowFilter.Order(
+            rawValue: defaults.string(forKey: Key.switcherOrder) ?? ""
+        ) ?? Default.order
+
         launchAtLogin = SMAppService.mainApp.status == .enabled
     }
 

--- a/Sources/OpenSwitchr/SettingsView.swift
+++ b/Sources/OpenSwitchr/SettingsView.swift
@@ -93,6 +93,10 @@ struct SettingsView: View {
                 Text("Applies to the switcher only. Dock previews always show every window of the application under the pointer, because that is the one you pointed at.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Text("A minimized window sits on no display, so “Only this display” never removes one. Otherwise a display setting would quietly hide everything in the Dock.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
             .disabled(!model.preferences.switcherEnabled)
 

--- a/Sources/OpenSwitchr/SettingsView.swift
+++ b/Sources/OpenSwitchr/SettingsView.swift
@@ -53,6 +53,49 @@ struct SettingsView: View {
                 }
             }
 
+            Section("Window list") {
+                Picker("Show", selection: Binding(
+                    get: { model.preferences.switcherApplicationScope },
+                    set: { model.preferences.switcherApplicationScope = $0 }
+                )) {
+                    ForEach(WindowFilter.ApplicationScope.allCases, id: \.self) { scope in
+                        Text(scope.title).tag(scope)
+                    }
+                }
+
+                Picker("Minimized windows", selection: Binding(
+                    get: { model.preferences.switcherMinimizedPolicy },
+                    set: { model.preferences.switcherMinimizedPolicy = $0 }
+                )) {
+                    ForEach(WindowFilter.MinimizedPolicy.allCases, id: \.self) { policy in
+                        Text(policy.title).tag(policy)
+                    }
+                }
+
+                Picker("Displays", selection: Binding(
+                    get: { model.preferences.switcherScreenScope },
+                    set: { model.preferences.switcherScreenScope = $0 }
+                )) {
+                    ForEach(WindowFilter.ScreenScope.allCases, id: \.self) { scope in
+                        Text(scope.title).tag(scope)
+                    }
+                }
+
+                Picker("Order", selection: Binding(
+                    get: { model.preferences.switcherOrder },
+                    set: { model.preferences.switcherOrder = $0 }
+                )) {
+                    ForEach(WindowFilter.Order.allCases, id: \.self) { order in
+                        Text(order.title).tag(order)
+                    }
+                }
+
+                Text("Applies to the switcher only. Dock previews always show every window of the application under the pointer, because that is the one you pointed at.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .disabled(!model.preferences.switcherEnabled)
+
             Section("Dock previews") {
                 Toggle("Show window previews on Dock hover", isOn: Binding(
                     get: { model.preferences.dockHoverEnabled },
@@ -72,6 +115,16 @@ struct SettingsView: View {
                     }
                 }
                 .disabled(!model.preferences.dockHoverEnabled)
+
+                Toggle("Switch instantly while a preview is open", isOn: Binding(
+                    get: { model.preferences.dockHoverInstantSwitch },
+                    set: { model.preferences.dockHoverInstantSwitch = $0 }
+                ))
+                .disabled(!model.preferences.dockHoverEnabled)
+
+                Text("The delay keeps a preview from appearing when you sweep across the Dock on the way somewhere else. Once one is open you have already asked for it, so moving to the next icon need not wait again.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Startup") {

--- a/Sources/OpenSwitchr/SwitcherController.swift
+++ b/Sources/OpenSwitchr/SwitcherController.swift
@@ -20,6 +20,13 @@ public final class SwitcherController {
     private var query = ""
     private var columnCount = 1
 
+    /// The screen this overlay is appearing on, decided once when it opens.
+    ///
+    /// It is both a layout input and a filter input, and the two have to agree:
+    /// deciding it twice is how a list scoped to "this display" ends up being
+    /// drawn on a different one.
+    private var surfaceScreen: NSScreen?
+
     public private(set) var isVisible = false
 
     /// Called whenever the overlay opens or closes, so the hotkey monitor knows
@@ -61,7 +68,8 @@ public final class SwitcherController {
     private func open(reverse: Bool) {
         guard !isVisible else { return }
         query = ""
-        visibleWindows = index.windows
+        surfaceScreen = OverlayPanel.screenWithMouse() ?? NSScreen.main
+        visibleWindows = baseWindows()
 
         guard !visibleWindows.isEmpty else { return }
 
@@ -74,9 +82,33 @@ public final class SwitcherController {
         present()
     }
 
+    /// The index, reduced to what the user configured this surface to show.
+    ///
+    /// A filter and a sort over a list that is already in memory, on the path
+    /// that puts the overlay on screen. It issues no accessibility read.
+    private func baseWindows() -> [WindowInfo] {
+        preferences.switcherFilter.apply(to: index.windows, context: filterContext())
+    }
+
+    private func filterContext() -> WindowFilter.Context {
+        WindowFilter.Context(frontmostPID: frontmostPID(), screen: surfaceScreen)
+    }
+
+    /// Which application the user is currently in.
+    ///
+    /// Read from the index rather than from `NSWorkspace.frontmostApplication`,
+    /// which is driven by notifications and is the value that has already
+    /// caused trouble here when read on a short path. The index is sorted
+    /// most-recently-used first, so its head is the window the user was last
+    /// in — which is the better answer anyway. The workspace is kept only as a
+    /// fallback for an empty index.
+    private func frontmostPID() -> pid_t? {
+        index.windows.first?.pid ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
+    }
+
     private func present() {
         let tileSize = tileSize()
-        let screen = OverlayPanel.screenWithMouse() ?? NSScreen.main
+        let screen = surfaceScreen ?? NSScreen.main
         let visible = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
 
         let maxWidth = min(visible.width * 0.86, 1400)
@@ -188,7 +220,7 @@ public final class SwitcherController {
     }
 
     private func refreshList(resetSelection: Bool) {
-        visibleWindows = WindowMatcher.filter(index.windows, query: query)
+        visibleWindows = WindowMatcher.filter(baseWindows(), query: query)
         if resetSelection {
             selectedIndex = 0
         } else {

--- a/Sources/OpenSwitchr/SwitcherController.swift
+++ b/Sources/OpenSwitchr/SwitcherController.swift
@@ -27,6 +27,26 @@ public final class SwitcherController {
     /// drawn on a different one.
     private var surfaceScreen: NSScreen?
 
+    /// The filter context for this whole session, frozen when the overlay
+    /// opens.
+    ///
+    /// Both of its inputs move underneath us otherwise. A background
+    /// application activating changes the frontmost pid — `noteFocus` is not
+    /// gated on the overlay being visible — and the pointer can cross a display
+    /// while the user types. Re-deriving the context on every keystroke would
+    /// change which windows the list is even *about* halfway through narrowing
+    /// it down, which reads as the switcher losing its mind rather than as a
+    /// setting doing its job.
+    private var sessionContext = WindowFilter.Context()
+
+    /// Whether the profile actually dropped anything this session.
+    ///
+    /// Measured rather than inferred from the settings: a profile that *could*
+    /// remove windows may not have removed any, and on a Space with no windows
+    /// at all, blaming the filter is the same kind of misdirection as the
+    /// message it replaced.
+    private var filterRemovedWindows = false
+
     public private(set) var isVisible = false
 
     /// Called whenever the overlay opens or closes, so the hotkey monitor knows
@@ -69,41 +89,69 @@ public final class SwitcherController {
         guard !isVisible else { return }
         query = ""
         surfaceScreen = OverlayPanel.screenWithMouse() ?? NSScreen.main
+        sessionContext = WindowFilter.Context(
+            frontmostPID: Self.frontmostPID(),
+            screen: surfaceScreen
+        )
+
+        // Identified before filtering, because the filter is entitled to remove
+        // it — "everything but the current application" does so by definition.
+        let currentWindowID = currentWindow()?.id
+
         visibleWindows = baseWindows()
 
-        guard !visibleWindows.isEmpty else { return }
+        selectedIndex = SwitcherSelection.initialIndex(
+            count: visibleWindows.count,
+            currentIndex: currentWindowID.flatMap { id in visibleWindows.firstIndex { $0.id == id } },
+            reverse: reverse
+        )
 
-        // Opening jumps straight to the previously used window, which is what
-        // makes a single hotkey press a fast toggle between two windows.
-        selectedIndex = reverse
-            ? visibleWindows.count - 1
-            : min(1, visibleWindows.count - 1)
-
+        // Presented even with nothing to show. The event tap swallows the
+        // keystroke either way, so returning here would leave the user with a
+        // dead ⌘-Tab *and* the system switcher suppressed, with no clue why —
+        // and a restrictive filter makes that reachable on purpose rather than
+        // only on an empty Space.
         present()
+    }
+
+    /// The window the user is looking at right now, or `nil` when that cannot
+    /// be established.
+    ///
+    /// Used **only** as the anchor the initial selection steps away from, never
+    /// as a filter input. `nil` is a real answer here and must not be papered
+    /// over with the index head: an application can be frontmost while owning
+    /// no window in the index — Finder after a click on the desktop is the
+    /// everyday case, since the desktop is not a switchable window — and
+    /// substituting some other application's window would make the selection
+    /// step past the very window the user wants.
+    private func currentWindow() -> WindowInfo? {
+        guard let pid = sessionContext.frontmostPID else { return nil }
+        return index.windows.first { $0.pid == pid }
     }
 
     /// The index, reduced to what the user configured this surface to show.
     ///
     /// A filter and a sort over a list that is already in memory, on the path
     /// that puts the overlay on screen. It issues no accessibility read.
+    ///
+    /// Records whether anything was actually dropped, because both call sites
+    /// need that answer and neither should have to recompute it.
     private func baseWindows() -> [WindowInfo] {
-        preferences.switcherFilter.apply(to: index.windows, context: filterContext())
-    }
-
-    private func filterContext() -> WindowFilter.Context {
-        WindowFilter.Context(frontmostPID: frontmostPID(), screen: surfaceScreen)
+        let all = index.windows
+        let kept = preferences.switcherFilter.apply(to: all, context: sessionContext)
+        filterRemovedWindows = kept.count < all.count
+        return kept
     }
 
     /// Which application the user is currently in.
     ///
-    /// Read from the index rather than from `NSWorkspace.frontmostApplication`,
-    /// which is driven by notifications and is the value that has already
-    /// caused trouble here when read on a short path. The index is sorted
-    /// most-recently-used first, so its head is the window the user was last
-    /// in — which is the better answer anyway. The workspace is kept only as a
-    /// fallback for an empty index.
-    private func frontmostPID() -> pid_t? {
-        index.windows.first?.pid ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
+    /// The rule, and the reason window order is not used for this, live in
+    /// `WindowFilter.Context.frontmostPID` where they can be tested.
+    private static func frontmostPID() -> pid_t? {
+        WindowFilter.Context.frontmostPID(
+            workspaceFrontmost: NSWorkspace.shared.frontmostApplication?.processIdentifier,
+            ownPID: ProcessInfo.processInfo.processIdentifier
+        )
     }
 
     private func present() {
@@ -124,7 +172,7 @@ public final class SwitcherController {
 
         prefetchThumbnails()
         render()
-        panel.showCentered(size: size)
+        panel.showCentered(size: size, on: surfaceScreen)
         setVisible(true)
     }
 
@@ -145,6 +193,7 @@ public final class SwitcherController {
                 thumbnails: thumbnails,
                 tileSize: tileSize(),
                 showsCloseButtons: preferences.showCloseButton,
+                isFiltered: filterRemovedWindows,
                 onActivate: { [weak self] index in
                     self?.selectedIndex = index
                     self?.commit()

--- a/Sources/OpenSwitchrCore/MRUTracker.swift
+++ b/Sources/OpenSwitchrCore/MRUTracker.swift
@@ -33,6 +33,13 @@ public struct MRUTracker {
     public mutating func touch(_ id: CGWindowID) {
         sequence += 1
         ranks[id] = sequence
+
+        // Keeps the two maps consistent by construction rather than by call
+        // order. `seed` only fills `discovery` for IDs it has never ranked, so
+        // an ID that reached `touch` first would have no discovery rank for the
+        // rest of the session and would sort last under "most recently opened"
+        // forever, with nothing to correct it.
+        if discovery[id] == nil { discovery[id] = sequence }
     }
 
     public mutating func forget(_ id: CGWindowID) {

--- a/Sources/OpenSwitchrCore/MRUTracker.swift
+++ b/Sources/OpenSwitchrCore/MRUTracker.swift
@@ -12,6 +12,10 @@ public struct MRUTracker {
     private var sequence: Int = 0
     private var ranks: [CGWindowID: Int] = [:]
 
+    /// The rank a window had when it was first seen, kept separately because
+    /// `ranks` moves on every focus and would otherwise lose it.
+    private var discovery: [CGWindowID: Int] = [:]
+
     public init() {}
 
     /// Seeds ordering for windows never seen before, using the front-to-back
@@ -21,6 +25,7 @@ public struct MRUTracker {
         for id in ids.reversed() where ranks[id] == nil {
             sequence += 1
             ranks[id] = sequence
+            discovery[id] = sequence
         }
     }
 
@@ -32,16 +37,26 @@ public struct MRUTracker {
 
     public mutating func forget(_ id: CGWindowID) {
         ranks.removeValue(forKey: id)
+        discovery.removeValue(forKey: id)
     }
 
     /// Drops bookkeeping for windows that no longer exist, so the map cannot
     /// grow without bound over a long uptime.
     public mutating func retain(only ids: Set<CGWindowID>) {
         ranks = ranks.filter { ids.contains($0.key) }
+        discovery = discovery.filter { ids.contains($0.key) }
     }
 
     public func rank(of id: CGWindowID) -> Int {
         ranks[id] ?? 0
+    }
+
+    /// When this window first entered the index. Higher means more recently.
+    ///
+    /// Only meaningful relative to other windows: for anything that was already
+    /// open at launch it is a seeded z-order position, not an opening time.
+    public func openedRank(of id: CGWindowID) -> Int {
+        discovery[id] ?? 0
     }
 
     /// Sorts windows most-recently-used first.

--- a/Sources/OpenSwitchrCore/SwitcherSelection.swift
+++ b/Sources/OpenSwitchrCore/SwitcherSelection.swift
@@ -1,0 +1,38 @@
+import CoreGraphics
+import Foundation
+
+/// Where the switcher's selection starts when the overlay opens.
+///
+/// Extracted and pure for the same reason `WindowIndex.focusTarget` is: the
+/// rule reads as if it were obvious, and it was wrong the moment the list
+/// stopped being a plain most-recently-used order.
+///
+/// The rule is "the window you would go back to" — the entry *after* the one
+/// you are currently in, so a single press of the hotkey is a fast toggle
+/// between two windows. That coincides with index 1 only while the list is in
+/// most-recently-used order *and* still contains the current window. Neither
+/// holds once a `WindowFilter` is applied: "everything but the current
+/// application" removes the current window by definition, and an alphabetical
+/// order puts something arbitrary at index 1 — possibly the window the user is
+/// already in, which makes the hotkey appear dead.
+public enum SwitcherSelection {
+
+    /// - Parameters:
+    ///   - count: how many windows the overlay is about to show. Must be > 0.
+    ///   - currentIndex: where the window the user is in ended up in that list,
+    ///     or `nil` if the list does not contain it.
+    ///   - reverse: whether the user opened the switcher backwards.
+    public static func initialIndex(count: Int, currentIndex: Int?, reverse: Bool) -> Int {
+        guard count > 0 else { return 0 }
+
+        guard let currentIndex, currentIndex >= 0, currentIndex < count else {
+            // The current window is not on the list, so there is nothing to
+            // step away from: the first entry going forwards, the last going
+            // back. Both are already the window the user most wants.
+            return reverse ? count - 1 : 0
+        }
+
+        let step = reverse ? -1 : 1
+        return ((currentIndex + step) % count + count) % count
+    }
+}

--- a/Sources/OpenSwitchrCore/WindowFilter+Screen.swift
+++ b/Sources/OpenSwitchrCore/WindowFilter+Screen.swift
@@ -15,12 +15,9 @@ public extension WindowFilter {
     /// display — the numbers happen to coincide — and silently matches the
     /// wrong display on any layout where the displays differ in height.
     static func coreGraphicsFrame(of screen: NSScreen) -> CGRect {
-        let primaryHeight = NSScreen.screens.first?.frame.height ?? screen.frame.height
-        return CGRect(
-            x: screen.frame.minX,
-            y: primaryHeight - screen.frame.maxY,
-            width: screen.frame.width,
-            height: screen.frame.height
+        coreGraphicsFrame(
+            appKitFrame: screen.frame,
+            primaryHeight: NSScreen.screens.first?.frame.height ?? screen.frame.height
         )
     }
 }

--- a/Sources/OpenSwitchrCore/WindowFilter+Screen.swift
+++ b/Sources/OpenSwitchrCore/WindowFilter+Screen.swift
@@ -1,0 +1,37 @@
+import AppKit
+import CoreGraphics
+
+// The AppKit bridge for `WindowFilter`, deliberately kept out of the filter
+// itself so that type stays testable without a window server.
+
+public extension WindowFilter {
+
+    /// An AppKit screen frame expressed the way `WindowInfo.frame` is.
+    ///
+    /// This conversion exists exactly once because it is the kind of thing that
+    /// drifts: CoreGraphics puts the origin at the top-left of the primary
+    /// display with y growing downwards, AppKit puts it at the bottom-left.
+    /// Comparing the two without the flip still looks right on a single
+    /// display — the numbers happen to coincide — and silently matches the
+    /// wrong display on any layout where the displays differ in height.
+    static func coreGraphicsFrame(of screen: NSScreen) -> CGRect {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? screen.frame.height
+        return CGRect(
+            x: screen.frame.minX,
+            y: primaryHeight - screen.frame.maxY,
+            width: screen.frame.width,
+            height: screen.frame.height
+        )
+    }
+}
+
+public extension WindowFilter.Context {
+
+    /// Builds a context for a surface that is about to appear on `screen`.
+    init(frontmostPID: pid_t?, screen: NSScreen?) {
+        self.init(
+            frontmostPID: frontmostPID,
+            screenFrame: screen.map(WindowFilter.coreGraphicsFrame(of:))
+        )
+    }
+}

--- a/Sources/OpenSwitchrCore/WindowFilter.swift
+++ b/Sources/OpenSwitchrCore/WindowFilter.swift
@@ -106,6 +106,27 @@ public struct WindowFilter: Equatable, Sendable {
             self.frontmostPID = frontmostPID
             self.screenFrame = screenFrame
         }
+
+        /// Which pid the application scope should treat as the current
+        /// application.
+        ///
+        /// The window server's frontmost application is the authoritative
+        /// answer, and deliberately the *only* one used. Window order is not an
+        /// acceptable substitute: the index promotes a newly *discovered*
+        /// window above everything else, so any background application opening
+        /// a window would be mistaken for the one the user is in — which is
+        /// exactly wrong for both `frontmostOnly` and `excludingFrontmost`.
+        ///
+        /// It also must never be our own pid. The overlay is a non-activating
+        /// panel precisely so the user's application stays frontmost, but if
+        /// that ever stopped holding, scoping to a process with no windows in
+        /// the index would empty the switcher — the one outcome it cannot
+        /// recover from. Returning `nil` instead means the scope is ignored and
+        /// everything is shown, which fails in the harmless direction.
+        public static func frontmostPID(workspaceFrontmost: pid_t?, ownPID: pid_t) -> pid_t? {
+            guard let workspaceFrontmost, workspaceFrontmost != ownPID else { return nil }
+            return workspaceFrontmost
+        }
     }
 
     public var applications: ApplicationScope
@@ -138,6 +159,33 @@ public struct WindowFilter: Equatable, Sendable {
         screens: .allScreens,
         order: .recentlyUsed
     )
+
+    /// What the switcher starts with: exactly the behaviour the app had before
+    /// this type existed.
+    ///
+    /// This is the *only* place those defaults are written down. `PreferencesStore`
+    /// registers them and falls back to them from here rather than repeating
+    /// the values, because a registered default and its parsing fallback are
+    /// two spellings of one number and they have drifted apart in this project
+    /// before.
+    public static let switcherDefault = WindowFilter()
+
+    /// The vertical flip between AppKit's screen geometry and the CoreGraphics
+    /// geometry `WindowInfo.frame` uses, with no AppKit involved so it can be
+    /// tested against synthetic display layouts.
+    ///
+    /// AppKit measures y upwards from the bottom-left of the primary display;
+    /// CoreGraphics measures it downwards from the top-left of the same
+    /// display. Both agree on x. `NSScreen`-flavoured callers go through
+    /// `coreGraphicsFrame(of:)`.
+    public static func coreGraphicsFrame(appKitFrame: CGRect, primaryHeight: CGFloat) -> CGRect {
+        CGRect(
+            x: appKitFrame.minX,
+            y: primaryHeight - appKitFrame.maxY,
+            width: appKitFrame.width,
+            height: appKitFrame.height
+        )
+    }
 
     // MARK: - Application
 
@@ -190,9 +238,9 @@ public struct WindowFilter: Equatable, Sendable {
             // filter cannot see would only be a chance to get it wrong.
             ordered = windows
         case .recentlyOpened:
-            ordered = windows.sorted { $0.openedRank > $1.openedRank }
+            ordered = Self.stableSorted(windows) { $0.openedRank > $1.openedRank }
         case .alphabetical:
-            ordered = windows.sorted { lhs, rhs in
+            ordered = Self.stableSorted(windows) { lhs, rhs in
                 let byApplication = lhs.appName.localizedCaseInsensitiveCompare(rhs.appName)
                 if byApplication != .orderedSame { return byApplication == .orderedAscending }
                 return lhs.displayTitle.localizedCaseInsensitiveCompare(rhs.displayTitle) == .orderedAscending
@@ -201,5 +249,28 @@ public struct WindowFilter: Equatable, Sendable {
 
         guard minimized == .showAfterOthers else { return ordered }
         return ordered.filter { !$0.isMinimized } + ordered.filter(\.isMinimized)
+    }
+
+    /// Sorts without letting equal elements move relative to each other.
+    ///
+    /// `Array.sorted(by:)` is explicitly *not* guaranteed stable, and equal
+    /// keys are not an edge case here: two untitled windows of the same
+    /// application compare equal on every field either comparator looks at, and
+    /// windows sharing a title are common. Because the incoming order is
+    /// most-recently-used and the list is re-ordered on every keystroke, an
+    /// unstable result would let tiles swap places under the user's fingers
+    /// for no reason. Decorating with the incoming position and using it as the
+    /// final tie-break is the same trick `WindowMatcher` already uses.
+    private static func stableSorted(
+        _ windows: [WindowInfo],
+        by areInIncreasingOrder: (WindowInfo, WindowInfo) -> Bool
+    ) -> [WindowInfo] {
+        windows.enumerated()
+            .sorted { lhs, rhs in
+                if areInIncreasingOrder(lhs.element, rhs.element) { return true }
+                if areInIncreasingOrder(rhs.element, lhs.element) { return false }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
     }
 }

--- a/Sources/OpenSwitchrCore/WindowFilter.swift
+++ b/Sources/OpenSwitchrCore/WindowFilter.swift
@@ -1,0 +1,205 @@
+import CoreGraphics
+import Foundation
+
+/// Which windows a surface wants, and in what order.
+///
+/// Both frontends read the same ``WindowIndex``, and they do not want the same
+/// set: a Dock preview is scoped to one application by definition, while the
+/// switcher is scoped to everything worth switching to. Holding that difference
+/// in one value type keeps it in data rather than in two call sites that drift,
+/// and keeps it testable — this is cheap to unit test and expensive to get
+/// subtly wrong, which is the same reason ``WindowMatcher`` is pure.
+///
+/// Applying a filter is a filter and a sort over a list that is already in
+/// memory. It performs no accessibility read of its own: every axis is answered
+/// from what the index already gathered, because cost tracks round trips.
+///
+/// Composition order is fixed and matters: **filter, then sort, then let a
+/// search query re-rank.** ``WindowMatcher/filter(_:query:)`` keeps the incoming
+/// order as its tie-breaker, so the sort has to have run before it.
+public struct WindowFilter: Equatable, Sendable {
+
+    /// Which applications contribute windows.
+    public enum ApplicationScope: String, CaseIterable, Sendable {
+        case all
+        case frontmostOnly
+        case excludingFrontmost
+
+        public var title: String {
+            switch self {
+            case .all: return "All applications"
+            case .frontmostOnly: return "Only the current application"
+            case .excludingFrontmost: return "Everything but the current application"
+            }
+        }
+    }
+
+    /// What happens to windows that are sitting in the Dock.
+    public enum MinimizedPolicy: String, CaseIterable, Sendable {
+        case show
+        case hide
+        /// Kept, but moved behind every window that is not minimized.
+        ///
+        /// This is a partition, not a sort key. Expressing it inside a
+        /// comparator yields something that is not a strict weak ordering, and
+        /// `sort` is entitled to behave badly with one.
+        case showAfterOthers
+
+        public var title: String {
+            switch self {
+            case .show: return "Show"
+            case .hide: return "Hide"
+            case .showAfterOthers: return "Show after the rest"
+            }
+        }
+    }
+
+    /// Whether windows on other displays are worth offering.
+    public enum ScreenScope: String, CaseIterable, Sendable {
+        case allScreens
+        case surfaceScreenOnly
+
+        public var title: String {
+            switch self {
+            case .allScreens: return "All displays"
+            case .surfaceScreenOnly: return "Only this display"
+            }
+        }
+    }
+
+    public enum Order: String, CaseIterable, Sendable {
+        case recentlyUsed
+        case recentlyOpened
+        case alphabetical
+
+        public var title: String {
+            switch self {
+            case .recentlyUsed: return "Most recently used"
+            case .recentlyOpened: return "Most recently opened"
+            case .alphabetical: return "Application, then title"
+            }
+        }
+    }
+
+    /// Everything the filter needs to know about the world it runs in.
+    ///
+    /// Passed in rather than read, so the type stays free of AppKit and can be
+    /// tested without a window server.
+    public struct Context: Equatable, Sendable {
+
+        /// The application the user is currently in.
+        ///
+        /// When this is `nil` the application scope is not applied at all: an
+        /// unknown frontmost application must not be allowed to empty the
+        /// switcher, and showing one window too many is the far cheaper
+        /// mistake.
+        public var frontmostPID: pid_t?
+
+        /// The screen the surface is about to appear on, **in the coordinate
+        /// space `WindowInfo.frame` uses** — CoreGraphics, origin at the
+        /// top-left of the primary display, y growing downwards. Converting an
+        /// AppKit screen frame is the caller's job, because only the caller
+        /// knows which screen it means.
+        public var screenFrame: CGRect?
+
+        public init(frontmostPID: pid_t? = nil, screenFrame: CGRect? = nil) {
+            self.frontmostPID = frontmostPID
+            self.screenFrame = screenFrame
+        }
+    }
+
+    public var applications: ApplicationScope
+    public var minimized: MinimizedPolicy
+    public var screens: ScreenScope
+    public var order: Order
+
+    public init(
+        applications: ApplicationScope = .all,
+        minimized: MinimizedPolicy = .show,
+        screens: ScreenScope = .allScreens,
+        order: Order = .recentlyUsed
+    ) {
+        self.applications = applications
+        self.minimized = minimized
+        self.screens = screens
+        self.order = order
+    }
+
+    /// What a Dock preview asks for.
+    ///
+    /// Not configurable, and deliberately permissive: the panel is already
+    /// scoped to one application by the icon the pointer is on, so every
+    /// further restriction can only remove windows the user explicitly asked to
+    /// see. Minimized windows especially — a window in the Dock is exactly what
+    /// someone hovering the Dock is looking for.
+    public static let dockPreview = WindowFilter(
+        applications: .all,
+        minimized: .show,
+        screens: .allScreens,
+        order: .recentlyUsed
+    )
+
+    // MARK: - Application
+
+    /// Filters and orders `windows`, which are expected to arrive
+    /// most-recently-used first, the way ``WindowIndex`` keeps them.
+    public func apply(to windows: [WindowInfo], context: Context = Context()) -> [WindowInfo] {
+        order(kept(windows, context: context))
+    }
+
+    private func kept(_ windows: [WindowInfo], context: Context) -> [WindowInfo] {
+        windows.filter { window in
+            includesApplication(of: window, context: context)
+                && (minimized != .hide || !window.isMinimized)
+                && includesScreen(of: window, context: context)
+        }
+    }
+
+    private func includesApplication(of window: WindowInfo, context: Context) -> Bool {
+        guard let frontmost = context.frontmostPID else { return true }
+        switch applications {
+        case .all: return true
+        case .frontmostOnly: return window.pid == frontmost
+        case .excludingFrontmost: return window.pid != frontmost
+        }
+    }
+
+    private func includesScreen(of window: WindowInfo, context: Context) -> Bool {
+        guard screens == .surfaceScreenOnly, let screenFrame = context.screenFrame else { return true }
+
+        // A minimized window is on no display at all, and the frame the window
+        // server still reports for it says nothing useful. Restricting by
+        // display would silently drop every minimized window as a side effect
+        // of an unrelated setting.
+        guard !window.isMinimized else { return true }
+
+        // Intersection rather than containment: a window straddling two
+        // displays belongs to both, and requiring containment would drop it
+        // from every list.
+        guard window.frame.width > 0, window.frame.height > 0 else { return true }
+        return screenFrame.intersects(window.frame)
+    }
+
+    private func order(_ windows: [WindowInfo]) -> [WindowInfo] {
+        let ordered: [WindowInfo]
+
+        switch order {
+        case .recentlyUsed:
+            // The index already hands windows over most-recently-used first,
+            // so this is deliberately the identity. Re-sorting by a rank the
+            // filter cannot see would only be a chance to get it wrong.
+            ordered = windows
+        case .recentlyOpened:
+            ordered = windows.sorted { $0.openedRank > $1.openedRank }
+        case .alphabetical:
+            ordered = windows.sorted { lhs, rhs in
+                let byApplication = lhs.appName.localizedCaseInsensitiveCompare(rhs.appName)
+                if byApplication != .orderedSame { return byApplication == .orderedAscending }
+                return lhs.displayTitle.localizedCaseInsensitiveCompare(rhs.displayTitle) == .orderedAscending
+            }
+        }
+
+        guard minimized == .showAfterOthers else { return ordered }
+        return ordered.filter { !$0.isMinimized } + ordered.filter(\.isMinimized)
+    }
+}

--- a/Sources/OpenSwitchrCore/WindowIndex.swift
+++ b/Sources/OpenSwitchrCore/WindowIndex.swift
@@ -7,9 +7,9 @@ import OSLog
 
 /// The single source of truth for open windows.
 ///
-/// This is the whole point of consolidating DockDoor-style previews and an
-/// AltTab-style switcher into one app: both frontends read from this index,
-/// so the expensive work of enumerating and tracking windows happens once.
+/// This is the whole point of consolidating Dock hover previews and a window
+/// switcher into one app: both frontends read from this index, so the
+/// expensive work of enumerating and tracking windows happens once.
 ///
 /// Scope is deliberately limited to the **current Space**. Reaching windows on
 /// other Spaces requires private SkyLight calls, which are out of bounds.
@@ -211,6 +211,12 @@ public final class WindowIndex {
 
         mru.seed(zOrdered: zOrdered)
         mru.retain(only: Set(result.map(\.id)))
+
+        // Stamped here rather than looked up later, so a pure filter can order
+        // by "most recently opened" without reaching back into the index.
+        for offset in result.indices {
+            result[offset].openedRank = mru.openedRank(of: result[offset].id)
+        }
 
         windows = mru.sorted(result)
         lastRebuildDuration = CFAbsoluteTimeGetCurrent() - started

--- a/Sources/OpenSwitchrCore/WindowInfo.swift
+++ b/Sources/OpenSwitchrCore/WindowInfo.swift
@@ -21,6 +21,16 @@ public struct WindowInfo: Identifiable, Equatable {
     public var isOnScreen: Bool
     public var element: AXUIElement?
 
+    /// Discovery order, higher meaning seen more recently.
+    ///
+    /// Filled in by ``WindowIndex`` from its own bookkeeping so that a pure
+    /// filter can order by "most recently opened" without reaching back into
+    /// the index. Windows that were already open when the app launched are
+    /// seeded back-to-front from z-order, because nothing records when a window
+    /// that predates this process was opened — the order among them is stable
+    /// and plausible rather than true.
+    public var openedRank: Int
+
     public init(
         id: CGWindowID,
         pid: pid_t,
@@ -30,7 +40,8 @@ public struct WindowInfo: Identifiable, Equatable {
         frame: CGRect,
         isMinimized: Bool,
         isOnScreen: Bool,
-        element: AXUIElement?
+        element: AXUIElement?,
+        openedRank: Int = 0
     ) {
         self.id = id
         self.pid = pid
@@ -41,6 +52,7 @@ public struct WindowInfo: Identifiable, Equatable {
         self.isMinimized = isMinimized
         self.isOnScreen = isOnScreen
         self.element = element
+        self.openedRank = openedRank
     }
 
     /// What the switcher shows as the primary label.

--- a/Sources/OpenSwitchrUI/OverlayPanel.swift
+++ b/Sources/OpenSwitchrUI/OverlayPanel.swift
@@ -59,11 +59,14 @@ public final class OverlayPanel: NSPanel {
         contentView = created
     }
 
-    /// Shows the panel centred on the screen that currently has the mouse,
-    /// which is the screen the user is looking at.
-    public func showCentered(size: NSSize) {
-        let screen = Self.screenWithMouse() ?? NSScreen.main
-        guard let screen else { return }
+    /// Shows the panel centred on `screen`, or on the screen that currently has
+    /// the mouse when none is given.
+    ///
+    /// Callers that already decided which screen they mean must pass it. The
+    /// switcher scopes its window list by display, so re-deriving the screen
+    /// here would let it filter for one display and draw on another.
+    public func showCentered(size: NSSize, on screen: NSScreen? = nil) {
+        guard let screen = screen ?? Self.screenWithMouse() ?? NSScreen.main else { return }
 
         let visible = screen.visibleFrame
         let origin = NSPoint(

--- a/Sources/OpenSwitchrUI/SwitcherView.swift
+++ b/Sources/OpenSwitchrUI/SwitcherView.swift
@@ -10,6 +10,14 @@ public struct SwitcherView: View {
     private let thumbnails: ThumbnailProvider
     private let tileSize: CGSize
     private let showsCloseButtons: Bool
+
+    /// Whether a non-default window filter is narrowing the list.
+    ///
+    /// Only used to tell the two empty states apart. "No open windows on this
+    /// Space" is a lie when there are windows and a setting is hiding them, and
+    /// it sends the user looking for the wrong problem.
+    private let isFiltered: Bool
+
     private let onActivate: (Int) -> Void
     private let onClose: (Int) -> Void
     private let onQuitApp: (Int) -> Void
@@ -22,6 +30,7 @@ public struct SwitcherView: View {
         thumbnails: ThumbnailProvider,
         tileSize: CGSize,
         showsCloseButtons: Bool = false,
+        isFiltered: Bool = false,
         onActivate: @escaping (Int) -> Void,
         onClose: @escaping (Int) -> Void = { _ in },
         onQuitApp: @escaping (Int) -> Void = { _ in },
@@ -33,6 +42,7 @@ public struct SwitcherView: View {
         self.thumbnails = thumbnails
         self.tileSize = tileSize
         self.showsCloseButtons = showsCloseButtons
+        self.isFiltered = isFiltered
         self.onActivate = onActivate
         self.onClose = onClose
         self.onQuitApp = onQuitApp
@@ -91,11 +101,18 @@ public struct SwitcherView: View {
             Image(systemName: "macwindow.badge.plus")
                 .font(.system(size: 28))
                 .foregroundStyle(.tertiary)
-            Text(query.isEmpty ? "No open windows on this Space" : "No matches")
+            Text(emptyMessage)
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, minHeight: 120)
+    }
+
+    private var emptyMessage: String {
+        if !query.isEmpty { return "No matches" }
+        return isFiltered
+            ? "No windows match the switcher's filter"
+            : "No open windows on this Space"
     }
 
     private var grid: some View {

--- a/Sources/openswitchr-diag/AppProbe.swift
+++ b/Sources/openswitchr-diag/AppProbe.swift
@@ -89,6 +89,18 @@ enum AppProbe {
         }
 
         usleep(250_000)
+        // The overlay has to survive the modifier simply being held. Nothing
+        // used to check that: this probe held for 250 ms and released, so an
+        // overlay that gives up while the user is still deciding which window
+        // they want was invisible to it.
+        if appearance != nil {
+            if let vanished = timeUntilPanelVanishes(within: 4.0, ignoring: panelsBefore) {
+                print(String(format: "  FAILED: overlay vanished %.1f s into the hold, with the modifier still down.", vanished))
+            } else {
+                print("  Held for 4 s: still on screen.")
+            }
+            probeDockInterference(panelsBefore: panelsBefore)
+        }
         key(modifier.key, down: false, flags: [])
         usleep(700_000)
 
@@ -100,6 +112,34 @@ enum AppProbe {
     }
 
     // MARK: - Dock hover
+
+    /// Moves the pointer onto the Dock while the switcher is still held open.
+    ///
+    /// Ordinary use, and worth a check of its own: both frontends put a
+    /// floating panel on screen, and a Dock preview appearing beside the
+    /// overlay must not take it away. Reaching for the mouse mid-switch is
+    /// exactly the sort of thing a synthetic press-and-release never does.
+    private static func probeDockInterference(panelsBefore: Set<Int>) {
+        let switcherPanels = Set(panels().keys).subtracting(panelsBefore)
+        guard !switcherPanels.isEmpty else { return }
+        guard let item = dockItems().first(where: {
+            ["Safari", "Google Chrome", "Microsoft Edge", "Finder"].contains($0.title)
+        }) else { return }
+
+        move(to: item.point)
+        usleep(150_000)
+        // A pointer that never moves again may not generate the events a hover
+        // monitor is waiting for.
+        move(to: CGPoint(x: item.point.x + 1, y: item.point.y))
+        usleep(900_000)
+
+        let survived = !Set(panels().keys).isDisjoint(with: switcherPanels)
+        print(survived
+            ? "  Survived the pointer reaching the Dock during the hold."
+            : "  FAILED: the overlay vanished when the pointer reached the Dock.")
+
+        parkPointer()
+    }
 
     private static func probeDockHover() {
         print("Dock hover preview")
@@ -203,6 +243,26 @@ enum AppProbe {
                 return (Date().timeIntervalSince(start), fresh.value)
             }
             usleep(5_000)
+        }
+        return nil
+    }
+
+    /// How long an already-visible overlay lasts, or `nil` if it outlives the
+    /// timeout.
+    ///
+    /// The counterpart to `waitForPanel`: that one proves the overlay arrives,
+    /// this one proves it stays. Both are needed, because "appears and then
+    /// disappears on its own" passes the first check.
+    private static func timeUntilPanelVanishes(
+        within timeout: TimeInterval,
+        ignoring baseline: Set<Int> = []
+    ) -> TimeInterval? {
+        let start = Date()
+        while Date().timeIntervalSince(start) < timeout {
+            if panels().first(where: { !baseline.contains($0.key) }) == nil {
+                return Date().timeIntervalSince(start)
+            }
+            usleep(50_000)
         }
         return nil
     }

--- a/Sources/openswitchr-diag/Diag.swift
+++ b/Sources/openswitchr-diag/Diag.swift
@@ -14,6 +14,7 @@ import OpenSwitchrCore
 ///     swift run openswitchr-diag              # window index and linking
 ///     swift run openswitchr-diag --capture    # also exercise ScreenCaptureKit
 ///     swift run openswitchr-diag --bench      # also time repeated rebuilds
+///     swift run openswitchr-diag --filters    # apply the filter profiles to real windows
 ///     swift run openswitchr-diag --probe-app  # drive the *installed* app
 @main
 @MainActor
@@ -83,6 +84,72 @@ enum Diag {
         }
         if arguments.contains("--audit-links") {
             auditLinks(windows)
+        }
+        if arguments.contains("--filters") {
+            reportFilters(windows)
+        }
+    }
+
+    /// Applies each surface's filter profile to the windows actually open.
+    ///
+    /// Everything here is covered by unit tests except the one axis that cannot
+    /// be: the display scope compares a window frame reported by CoreGraphics
+    /// against a screen frame AppKit reports in the opposite vertical
+    /// direction. A wrong flip still looks correct on a single display, because
+    /// the two coordinate spaces coincide there, so the only way to judge it is
+    /// against the displays attached to this Mac.
+    private static func reportFilters(_ windows: [WindowInfo]) {
+        let frontmost = windows.first?.pid
+        let context = WindowFilter.Context(frontmostPID: frontmost)
+
+        print("")
+        print("Filter profiles")
+        if let frontmost, let name = windows.first?.appName {
+            print("Current application: \(name) (pid \(frontmost))")
+        }
+
+        func report(_ label: String, _ filter: WindowFilter, _ context: WindowFilter.Context) {
+            let kept = filter.apply(to: windows, context: context)
+            print("  " + pad(label, 36) + "\(kept.count)/\(windows.count)")
+        }
+
+        report("Dock preview profile", .dockPreview, WindowFilter.Context())
+        report("Switcher, defaults", WindowFilter(), context)
+        report("Only the current application", WindowFilter(applications: .frontmostOnly), context)
+        report("Everything but the current one", WindowFilter(applications: .excludingFrontmost), context)
+        report("Minimized hidden", WindowFilter(minimized: .hide), context)
+        report("Minimized last", WindowFilter(minimized: .showAfterOthers), context)
+
+        print("")
+        print("Display scope, against the attached displays")
+        let scoped = WindowFilter(screens: .surfaceScreenOnly)
+        var reachable = Set<CGWindowID>()
+
+        for (offset, screen) in NSScreen.screens.enumerated() {
+            let frame = WindowFilter.coreGraphicsFrame(of: screen)
+            let kept = scoped.apply(to: windows, context: .init(screenFrame: frame))
+            reachable.formUnion(kept.map(\.id))
+
+            let geometry = "\(Int(frame.width))×\(Int(frame.height)) at \(Int(frame.minX)),\(Int(frame.minY))"
+            print("  " + pad("Display \(offset + 1)  \(geometry)", 36) + "\(kept.count)/\(windows.count)")
+        }
+
+        // The check that matters: scoping by display must never make a window
+        // unreachable from every display. One that no display claims is either
+        // a coordinate flip that is wrong, or a window somewhere nobody can
+        // see it.
+        let unreachable = windows.filter { !reachable.contains($0.id) }
+        print("")
+        if unreachable.isEmpty {
+            print("Every window is claimed by at least one display.")
+        } else {
+            print("Claimed by no display: \(unreachable.count)")
+            for window in unreachable {
+                let frame = window.frame
+                print("  " + pad(short(window.appName, 20), 22)
+                      + pad(window.isMinimized ? "minimized" : "on screen", 12)
+                      + "\(Int(frame.width))×\(Int(frame.height)) at \(Int(frame.minX)),\(Int(frame.minY))")
+            }
         }
     }
 

--- a/Tests/OpenSwitchrCoreTests/MRUTrackerTests.swift
+++ b/Tests/OpenSwitchrCoreTests/MRUTrackerTests.swift
@@ -78,4 +78,56 @@ struct MRUTrackerTests {
 
         #expect(tracker.rank(of: 1) == 0)
     }
+
+    // MARK: - Discovery order
+
+    @Test("Discovery order follows front-to-back z-order, like use order does")
+    func seedRecordsDiscovery() {
+        var tracker = MRUTracker()
+        tracker.seed(zOrdered: [1, 2, 3])
+
+        // Seeded back-to-front, so the frontmost window is the most recent.
+        #expect(tracker.openedRank(of: 1) > tracker.openedRank(of: 2))
+        #expect(tracker.openedRank(of: 2) > tracker.openedRank(of: 3))
+    }
+
+    @Test("Using a window does not make it look newly opened")
+    func touchLeavesDiscoveryAlone() {
+        // The whole point of the second map: "most recently opened" must not
+        // collapse into "most recently used".
+        var tracker = MRUTracker()
+        tracker.seed(zOrdered: [1, 2, 3])
+        let before = tracker.openedRank(of: 3)
+
+        tracker.touch(3)
+
+        #expect(tracker.rank(of: 3) > tracker.rank(of: 1))
+        #expect(tracker.openedRank(of: 3) == before)
+        #expect(tracker.openedRank(of: 1) > tracker.openedRank(of: 3))
+    }
+
+    @Test("A window first seen through use still gets a discovery rank")
+    func touchSeedsDiscoveryForUnknownWindow() {
+        // `seed` skips anything already ranked, so without this the window
+        // would have no discovery rank for the rest of the session and would
+        // sort last under "most recently opened" forever.
+        var tracker = MRUTracker()
+        tracker.touch(9)
+        tracker.seed(zOrdered: [9])
+
+        #expect(tracker.openedRank(of: 9) > 0)
+    }
+
+    @Test("Discovery bookkeeping is pruned with the rest")
+    func retainPrunesDiscovery() {
+        var tracker = MRUTracker()
+        tracker.seed(zOrdered: [1, 2])
+        tracker.retain(only: [1])
+
+        #expect(tracker.openedRank(of: 1) > 0)
+        #expect(tracker.openedRank(of: 2) == 0)
+
+        tracker.forget(1)
+        #expect(tracker.openedRank(of: 1) == 0)
+    }
 }

--- a/Tests/OpenSwitchrCoreTests/SwitcherSelectionTests.swift
+++ b/Tests/OpenSwitchrCoreTests/SwitcherSelectionTests.swift
@@ -1,0 +1,63 @@
+import Testing
+
+@testable import OpenSwitchrCore
+
+@Suite("SwitcherSelection")
+struct SwitcherSelectionTests {
+
+    @Test("Opening forwards lands on the entry after the current window")
+    func forwardFromHead() {
+        // The classic case: most-recently-used order, current window at the
+        // head, so a single press toggles to the previous window.
+        #expect(SwitcherSelection.initialIndex(count: 5, currentIndex: 0, reverse: false) == 1)
+    }
+
+    @Test("Opening backwards lands on the entry before the current window")
+    func backwardFromHead() {
+        #expect(SwitcherSelection.initialIndex(count: 5, currentIndex: 0, reverse: true) == 4)
+    }
+
+    @Test("The current window is stepped away from wherever it sits")
+    func stepsFromAnyPosition() {
+        // A different order puts the current window somewhere else entirely,
+        // and index 1 would then be arbitrary.
+        #expect(SwitcherSelection.initialIndex(count: 5, currentIndex: 3, reverse: false) == 4)
+        #expect(SwitcherSelection.initialIndex(count: 5, currentIndex: 3, reverse: true) == 2)
+    }
+
+    @Test("Stepping wraps around both ends")
+    func wraps() {
+        #expect(SwitcherSelection.initialIndex(count: 5, currentIndex: 4, reverse: false) == 0)
+        #expect(SwitcherSelection.initialIndex(count: 5, currentIndex: 0, reverse: true) == 4)
+    }
+
+    @Test("A filtered-out current window selects the first entry, not the second")
+    func currentWindowMissing() {
+        // "Everything but the current application" removes the current window
+        // by definition, so the head of that list is already the window the
+        // user wants. Skipping to index 1 would step past it.
+        #expect(SwitcherSelection.initialIndex(count: 5, currentIndex: nil, reverse: false) == 0)
+        #expect(SwitcherSelection.initialIndex(count: 5, currentIndex: nil, reverse: true) == 4)
+    }
+
+    @Test("A single window is always the selection")
+    func singleWindow() {
+        #expect(SwitcherSelection.initialIndex(count: 1, currentIndex: 0, reverse: false) == 0)
+        #expect(SwitcherSelection.initialIndex(count: 1, currentIndex: 0, reverse: true) == 0)
+        #expect(SwitcherSelection.initialIndex(count: 1, currentIndex: nil, reverse: false) == 0)
+    }
+
+    @Test("An empty list selects nothing rather than trapping")
+    func emptyList() {
+        // The overlay is now presented even with nothing to show, so this is
+        // reachable rather than theoretical.
+        #expect(SwitcherSelection.initialIndex(count: 0, currentIndex: nil, reverse: false) == 0)
+        #expect(SwitcherSelection.initialIndex(count: 0, currentIndex: 0, reverse: true) == 0)
+    }
+
+    @Test("An out-of-range current index is treated as absent")
+    func outOfRangeCurrentIndex() {
+        #expect(SwitcherSelection.initialIndex(count: 3, currentIndex: 9, reverse: false) == 0)
+        #expect(SwitcherSelection.initialIndex(count: 3, currentIndex: -1, reverse: false) == 0)
+    }
+}

--- a/Tests/OpenSwitchrCoreTests/WindowFilterTests.swift
+++ b/Tests/OpenSwitchrCoreTests/WindowFilterTests.swift
@@ -1,0 +1,216 @@
+import CoreGraphics
+import Testing
+
+@testable import OpenSwitchrCore
+
+@Suite("WindowFilter")
+struct WindowFilterTests {
+
+    private func window(
+        id: CGWindowID,
+        app: String = "Safari",
+        title: String = "Window",
+        pid: pid_t = 1,
+        minimized: Bool = false,
+        frame: CGRect = CGRect(x: 0, y: 0, width: 800, height: 600),
+        openedRank: Int = 0
+    ) -> WindowInfo {
+        WindowInfo(
+            id: id,
+            pid: pid,
+            bundleID: "com.example.\(app.lowercased())",
+            appName: app,
+            title: title,
+            frame: frame,
+            isMinimized: minimized,
+            isOnScreen: !minimized,
+            element: nil,
+            openedRank: openedRank
+        )
+    }
+
+    // MARK: - Defaults
+
+    @Test("The default filter changes nothing at all")
+    func defaultIsIdentity() {
+        let windows = [window(id: 1), window(id: 2), window(id: 3)]
+        #expect(WindowFilter().apply(to: windows).map(\.id) == [1, 2, 3])
+    }
+
+    @Test("The Dock preview profile keeps minimized windows, which is the point of hovering the Dock")
+    func dockPreviewKeepsMinimized() {
+        let windows = [window(id: 1), window(id: 2, minimized: true)]
+        #expect(WindowFilter.dockPreview.apply(to: windows).map(\.id) == [1, 2])
+    }
+
+    // MARK: - Application scope
+
+    @Test("Only the current application keeps that application's windows")
+    func frontmostOnly() {
+        let windows = [
+            window(id: 1, app: "Safari", pid: 10),
+            window(id: 2, app: "Xcode", pid: 20),
+            window(id: 3, app: "Safari", pid: 10)
+        ]
+        let filter = WindowFilter(applications: .frontmostOnly)
+        let result = filter.apply(to: windows, context: .init(frontmostPID: 10))
+
+        #expect(result.map(\.id) == [1, 3])
+    }
+
+    @Test("Everything but the current application is the exact complement")
+    func excludingFrontmost() {
+        let windows = [
+            window(id: 1, app: "Safari", pid: 10),
+            window(id: 2, app: "Xcode", pid: 20)
+        ]
+        let filter = WindowFilter(applications: .excludingFrontmost)
+
+        #expect(filter.apply(to: windows, context: .init(frontmostPID: 10)).map(\.id) == [2])
+    }
+
+    @Test("An unknown frontmost application must not empty the list")
+    func unknownFrontmostShowsEverything() {
+        let windows = [
+            window(id: 1, app: "Safari", pid: 10),
+            window(id: 2, app: "Xcode", pid: 20)
+        ]
+
+        // Both scopes would otherwise be free to remove every window, which is
+        // the one outcome a switcher can never recover from.
+        #expect(WindowFilter(applications: .frontmostOnly).apply(to: windows).map(\.id) == [1, 2])
+        #expect(WindowFilter(applications: .excludingFrontmost).apply(to: windows).map(\.id) == [1, 2])
+    }
+
+    // MARK: - Minimized
+
+    @Test("Hiding minimized windows removes them")
+    func hideMinimized() {
+        let windows = [window(id: 1), window(id: 2, minimized: true), window(id: 3)]
+        #expect(WindowFilter(minimized: .hide).apply(to: windows).map(\.id) == [1, 3])
+    }
+
+    @Test("Showing minimized windows last is a partition that preserves the order within each half")
+    func minimizedAfterOthers() {
+        let windows = [
+            window(id: 1, minimized: true),
+            window(id: 2),
+            window(id: 3, minimized: true),
+            window(id: 4)
+        ]
+
+        #expect(WindowFilter(minimized: .showAfterOthers).apply(to: windows).map(\.id) == [2, 4, 1, 3])
+    }
+
+    @Test("The partition runs after the sort, not inside its comparator")
+    func minimizedPartitionAppliesToSortedOrder() {
+        let windows = [
+            window(id: 1, app: "Zed", minimized: true),
+            window(id: 2, app: "Safari"),
+            window(id: 3, app: "Arc", minimized: true),
+            window(id: 4, app: "Xcode")
+        ]
+
+        let filter = WindowFilter(minimized: .showAfterOthers, order: .alphabetical)
+
+        // Alphabetical within each half: Safari before Xcode, then Arc before Zed.
+        #expect(filter.apply(to: windows).map(\.id) == [2, 4, 3, 1])
+    }
+
+    // MARK: - Screen scope
+
+    @Test("Restricting to one display drops windows that do not touch it")
+    func screenScopeDropsOtherDisplays() {
+        let onThisScreen = window(id: 1, frame: CGRect(x: 100, y: 100, width: 400, height: 300))
+        let onAnotherScreen = window(id: 2, frame: CGRect(x: 2000, y: 100, width: 400, height: 300))
+
+        let filter = WindowFilter(screens: .surfaceScreenOnly)
+        let screen = CGRect(x: 0, y: 0, width: 1440, height: 900)
+
+        #expect(filter.apply(to: [onThisScreen, onAnotherScreen], context: .init(screenFrame: screen)).map(\.id) == [1])
+    }
+
+    @Test("A window straddling two displays belongs to both")
+    func straddlingWindowIsKept() {
+        let straddling = window(id: 1, frame: CGRect(x: 1300, y: 100, width: 400, height: 300))
+        let filter = WindowFilter(screens: .surfaceScreenOnly)
+
+        #expect(filter.apply(to: [straddling], context: .init(screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900))).map(\.id) == [1])
+    }
+
+    @Test("Minimized windows survive a display restriction, because they are on no display")
+    func minimizedExemptFromScreenScope() {
+        // Its reported frame is off this screen, which is exactly the trap:
+        // restricting by display would silently delete every minimized window.
+        let minimized = window(id: 1, minimized: true, frame: CGRect(x: 5000, y: 5000, width: 1, height: 1))
+        let filter = WindowFilter(screens: .surfaceScreenOnly)
+
+        #expect(filter.apply(to: [minimized], context: .init(screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900))).map(\.id) == [1])
+    }
+
+    @Test("Without a screen frame the display restriction does nothing")
+    func screenScopeNeedsAFrame() {
+        let windows = [window(id: 1, frame: CGRect(x: 9000, y: 9000, width: 10, height: 10))]
+        #expect(WindowFilter(screens: .surfaceScreenOnly).apply(to: windows).map(\.id) == [1])
+    }
+
+    // MARK: - Order
+
+    @Test("Most recently used keeps the order the index handed over")
+    func recentlyUsedIsIdentity() {
+        let windows = [window(id: 3), window(id: 1), window(id: 2)]
+        #expect(WindowFilter(order: .recentlyUsed).apply(to: windows).map(\.id) == [3, 1, 2])
+    }
+
+    @Test("Most recently opened sorts by discovery, newest first")
+    func recentlyOpened() {
+        let windows = [
+            window(id: 1, openedRank: 5),
+            window(id: 2, openedRank: 9),
+            window(id: 3, openedRank: 7)
+        ]
+        #expect(WindowFilter(order: .recentlyOpened).apply(to: windows).map(\.id) == [2, 3, 1])
+    }
+
+    @Test("Alphabetical sorts by application first and title second")
+    func alphabetical() {
+        let windows = [
+            window(id: 1, app: "Safari", title: "Zebra"),
+            window(id: 2, app: "Arc", title: "Beta"),
+            window(id: 3, app: "Safari", title: "Alpha")
+        ]
+        #expect(WindowFilter(order: .alphabetical).apply(to: windows).map(\.id) == [2, 3, 1])
+    }
+
+    @Test("Alphabetical ignores case, so a lowercase title does not sort to the end")
+    func alphabeticalIsCaseInsensitive() {
+        let windows = [
+            window(id: 1, app: "Safari", title: "beta"),
+            window(id: 2, app: "Safari", title: "Alpha")
+        ]
+        #expect(WindowFilter(order: .alphabetical).apply(to: windows).map(\.id) == [2, 1])
+    }
+
+    // MARK: - Composition
+
+    @Test("Filtering happens before ordering")
+    func filterRunsBeforeSort() {
+        let windows = [
+            window(id: 1, app: "Arc", pid: 20),
+            window(id: 2, app: "Safari", pid: 10),
+            window(id: 3, app: "Zed", pid: 10)
+        ]
+
+        let filter = WindowFilter(applications: .frontmostOnly, order: .alphabetical)
+        let result = filter.apply(to: windows, context: .init(frontmostPID: 10))
+
+        // Arc would sort first if the sort had seen it.
+        #expect(result.map(\.id) == [2, 3])
+    }
+
+    @Test("A filter that removes everything returns an empty list rather than falling back")
+    func canReturnNothing() {
+        let windows = [window(id: 1, minimized: true)]
+        #expect(WindowFilter(minimized: .hide).apply(to: windows).isEmpty)
+    }
+}

--- a/Tests/OpenSwitchrCoreTests/WindowFilterTests.swift
+++ b/Tests/OpenSwitchrCoreTests/WindowFilterTests.swift
@@ -102,7 +102,7 @@ struct WindowFilterTests {
         #expect(WindowFilter(minimized: .showAfterOthers).apply(to: windows).map(\.id) == [2, 4, 1, 3])
     }
 
-    @Test("The partition runs after the sort, not inside its comparator")
+    @Test("Minimized windows go last within whatever order was chosen")
     func minimizedPartitionAppliesToSortedOrder() {
         let windows = [
             window(id: 1, app: "Zed", minimized: true),
@@ -115,6 +115,102 @@ struct WindowFilterTests {
 
         // Alphabetical within each half: Safari before Xcode, then Arc before Zed.
         #expect(filter.apply(to: windows).map(\.id) == [2, 4, 3, 1])
+    }
+
+    // MARK: - Ordering stability
+
+    @Test("Windows that compare equal keep the order the index handed over")
+    func alphabeticalIsStable() {
+        // Same application, same title: every field either comparator looks at
+        // is equal, so an unstable sort is free to return these in any order.
+        // The incoming order is most-recently-used, and the list is re-ordered
+        // on every keystroke, so instability would move tiles under the user.
+        let windows = (1...8).map { window(id: CGWindowID($0), app: "Safari", title: "Untitled") }
+        let result = WindowFilter(order: .alphabetical).apply(to: windows)
+
+        #expect(result.map(\.id) == [1, 2, 3, 4, 5, 6, 7, 8])
+    }
+
+    @Test("Equal discovery ranks also keep the incoming order")
+    func recentlyOpenedIsStable() {
+        let windows = (1...8).map { window(id: CGWindowID($0), openedRank: 4) }
+        let result = WindowFilter(order: .recentlyOpened).apply(to: windows)
+
+        #expect(result.map(\.id) == [1, 2, 3, 4, 5, 6, 7, 8])
+    }
+
+    @Test("The minimized partition preserves the incoming order inside each half")
+    func partitionIsStableUnderIdentityOrder() {
+        // Under `recentlyUsed` there is no sort at all, so this is the case
+        // that catches an *unstable* comparator-based implementation: only
+        // something that leaves the two halves alone can keep 2 before 4 and 1
+        // before 3.
+        let windows = [
+            window(id: 1, minimized: true),
+            window(id: 2),
+            window(id: 3, minimized: true),
+            window(id: 4)
+        ]
+
+        #expect(WindowFilter(minimized: .showAfterOthers).apply(to: windows).map(\.id) == [2, 4, 1, 3])
+    }
+
+    // MARK: - Frontmost resolution
+
+    @Test("The frontmost application comes from the workspace, never from window order")
+    func frontmostPIDUsesWorkspace() {
+        #expect(WindowFilter.Context.frontmostPID(workspaceFrontmost: 42, ownPID: 7) == 42)
+    }
+
+    @Test("Our own process is never treated as the current application")
+    func frontmostPIDRefusesOwnProcess() {
+        // Scoping to a process that owns no window in the index would empty the
+        // switcher, which is the one outcome it cannot recover from. Returning
+        // nil ignores the scope instead.
+        #expect(WindowFilter.Context.frontmostPID(workspaceFrontmost: 7, ownPID: 7) == nil)
+    }
+
+    @Test("An unknown workspace frontmost yields nil rather than a guess")
+    func frontmostPIDWithoutWorkspace() {
+        #expect(WindowFilter.Context.frontmostPID(workspaceFrontmost: nil, ownPID: 7) == nil)
+    }
+
+    // MARK: - Screen coordinate conversion
+
+    @Test("On a single display the conversion is the identity")
+    func conversionOnPrimaryDisplay() {
+        let primary = CGRect(x: 0, y: 0, width: 1440, height: 900)
+        #expect(WindowFilter.coreGraphicsFrame(appKitFrame: primary, primaryHeight: 900) == primary)
+    }
+
+    @Test("A display above the primary lands at a negative y")
+    func conversionForDisplayAbove() {
+        // AppKit: sits on top of a 1440-high primary, so its frame starts at
+        // y = 1440. CoreGraphics measures downwards from the primary's top, so
+        // it has to end up above the origin.
+        let above = CGRect(x: 913, y: 1440, width: 1920, height: 1080)
+        let converted = WindowFilter.coreGraphicsFrame(appKitFrame: above, primaryHeight: 1440)
+
+        #expect(converted == CGRect(x: 913, y: -1080, width: 1920, height: 1080))
+    }
+
+    @Test("A display below the primary lands at a positive y")
+    func conversionForDisplayBelow() {
+        let below = CGRect(x: 0, y: -1080, width: 1920, height: 1080)
+        let converted = WindowFilter.coreGraphicsFrame(appKitFrame: below, primaryHeight: 1440)
+
+        #expect(converted == CGRect(x: 0, y: 1440, width: 1920, height: 1080))
+    }
+
+    @Test("A shorter secondary aligned to the primary's bottom keeps its bottom aligned")
+    func conversionForShorterSecondary() {
+        // The trap the flip exists for: taking the AppKit origin unchanged
+        // would put this display at y = 0, level with the primary's *top*,
+        // when it is actually level with its bottom.
+        let secondary = CGRect(x: 1440, y: 0, width: 1280, height: 800)
+        let converted = WindowFilter.coreGraphicsFrame(appKitFrame: secondary, primaryHeight: 1440)
+
+        #expect(converted == CGRect(x: 1440, y: 640, width: 1280, height: 800))
     }
 
     // MARK: - Screen scope


### PR DESCRIPTION
Stacked on #1, because that is where the code is — this branch targets
`trsdn-openswitch-architecture-plan`, not `main`.

First slice of #20: the filter foundation (#6) and the smallest change that
makes the Dock preview feel different (#13).

## What changed

**`WindowFilter`** — one pure value type saying which windows a surface wants
and in what order, applied by both frontends. Four axes: application scope,
minimized handling, display scope, order. The switcher's profile is
configurable in Settings; the Dock preview's is fixed and permissive, because
the pointer already chose the application.

**Defaults reproduce today's behaviour exactly.** Nothing changes for an
existing install until it asks for something.

**Dock previews switch instantly while one is open.** The delay exists so that
sweeping across the Dock on the way elsewhere does not fire a panel; once one is
up, that question has been answered.

## Two traps, both pinned by tests

- *"Show after the rest" is a partition, not a comparator clause.* Putting it in
  the comparator produces something that is not a strict weak ordering, and
  `sort` is entitled to misbehave with one.
- *A minimized window is exempt from the display scope.* It is on no display,
  and the frame the window server still reports for it would otherwise let an
  unrelated display setting quietly delete every window in the Dock.

## The axis a unit test cannot judge

The display scope compares a CoreGraphics window frame against an AppKit screen
frame measured in the opposite vertical direction. A wrong flip still looks
correct on a single display, because the two spaces coincide there. So the
conversion exists in exactly one place, and `openswitchr-diag --filters` applies
the scope to every attached display and asserts that no window is claimed by
none of them.

Measured on a four-display layout with three displays above the primary:

```
Filter profiles
Current application: GitHub Copilot (pid 4264)
  Dock preview profile                21/21
  Switcher, defaults                  21/21
  Only the current application        1/21
  Everything but the current one      20/21
  Minimized hidden                    19/21
  Minimized last                      21/21

Display scope, against the attached displays
  Display 1  5120×1440 at 0,0         21/21
  Display 2  1920×1080 at 2833,-1080  2/21
  Display 3  1920×1080 at -1007,-1080 2/21
  Display 4  1920×1080 at 913,-1080   2/21

Every window is claimed by at least one display.
```

The `2/21` on the secondary displays is the minimized exemption doing its job:
19 windows are on the primary, and the 2 minimized ones are claimed everywhere
because they are nowhere.

## Verification

- `swift build -c release` — clean, no warnings.
- `swift test` — 66 tests, 18 of them new. (`AGENTS.md` said 42; it was already
  stale, and now says 66.)
- `bash scripts/build-app.sh` — bundles and signs.
- `openswitchr-diag --probe-app` against the installed build: overlay appears,
  system switcher suppressed, focus actually moved, and the Dock icon hovered
  twice with both passes appearing and hiding.
- `openswitchr-diag --filters` — output above.

**Not verified, stated plainly:**

- The Settings pickers are unclicked. Unit tests do not render and the probe
  does not drive Settings, so "the picker writes the preference and the switcher
  reads it" is verified by reading the code, not by using it.
- The instant-switch path is *not* covered by `--probe-app`. The probe hovers
  the same icon twice with nothing on screen in between, so it never moves from
  one icon to another while a panel is up — which is the only case #13 changes.
  What the probe does show is that the delay still applies to the first panel:
  with `dockHoverDelay` at 0.35 s it measured 306 ms and 303 ms, against 2 ms
  with the delay at 0.

One aside worth recording, because it cost a detour: this machine had
`dockHoverDelay = 0` stored from earlier testing, which made the first probe
look like the delay had been removed. `AGENTS.md` already warns about exactly
this, and it was right.


---

# Review

Three reviewers — design, diff, and security — over three rounds. Round two found real bugs in the round one fixes, which is why there was a round three. Round three produced one residual and nothing else, so it was the last.

## Round 1 — five blocking findings

| Finding | Resolution |
|---|---|
| "Current application" was derived from window order. `MRUTracker.seed` ranks a newly *discovered* window above everything known, so a background app opening a window took the MRU head without activating, and both application scopes then filtered against the wrong app. Found independently by two reviewers. | Pure, tested `WindowFilter.Context.frontmostPID`: workspace frontmost, never our own pid, otherwise `nil` so the scope is ignored rather than guessed. |
| The initial selection offset of 1 assumed the list starts with the current window — false for `excludingFrontmost` by definition, and for any non-MRU order. | `SwitcherSelection`, pure and tested: locate the current window in the filtered list and step one from it. |
| An empty filtered result made `⌘-Tab` completely inert: the tap swallows the keystroke either way, so the system switcher stayed suppressed and nothing appeared. | The overlay is always presented, with an empty state that names the actual reason. |
| `Array.sorted(by:)` is not stable, and equal keys are ordinary — two untitled windows of one app compare equal on every field. | `stableSorted` decorates with the incoming position, as `WindowMatcher` already did. |
| The instant Dock path resolved before the asynchronous rebuild it had just triggered, so a hover could find nothing and never retry. | `unresolvedItem` plus `indexDidRebuild()`. |

Plus: the screen was decided twice (`showCentered` re-derived it, so the switcher could scope to one display and draw on another); the filter context was only half frozen (the pid was re-read per keystroke); the switcher defaults existed in two places; and `MRUTracker.touch` did not maintain the new map.

## Round 2 — the fixes had bugs

| Finding | Resolution |
|---|---|
| The Dock retry re-armed on **every** attempt, so an icon that genuinely has nothing here retried on every index rebuild for as long as the pointer sat on it — each pass running `hide()` into `forgetLastHover()`, coupling unrelated window churn to Dock hover state. | One shot: `show(for:isRetry:)` arms only on a first attempt. |
| `unresolvedItem` survived the pointer leaving the Dock, because `scheduleHide()` returns early in exactly the state an unresolved hover leaves behind. | Cleared in `hoverChanged(to: nil)`. |
| `isFiltered` over-claimed: ordering and "minimized last" cannot remove anything, so choosing alphabetical order made a genuinely empty Space blame the filter. | Measured from whether the filter actually dropped windows, not from whether it could. |
| `currentWindow()` still substituted the index head when the frontmost app owned nothing indexed — Finder after a click on the desktop. Found independently by two reviewers. | Returns `nil`, making `SwitcherSelection`'s documented nil path reachable. |

## Round 3 — one residual

The rebuild-completion guard was on one of the two paths, and it was taken where the rebuild was *scheduled* rather than where it *arrived* — a rebuild is in flight for tens of milliseconds and the overlay can open during it. Both paths now go through one `rebuildFinished()`.

`WindowFilter.canRemoveWindows` was added in round 2 and removed again in round 3 once the measured version superseded it, rather than left as unused public API.

## Consciously left open, and filed

- **#23** — releasing the modifier before the overlay appears can strand it. Pre-existing, in the event tap that has already killed the hotkey in the field once. This branch makes the benign variant reachable (an empty overlay lingers); the dangerous variant, where recovery activates a window the user never chose, predates it and is unchanged. All three reviewers agreed this was the wrong thing to disturb here.
- **#24** — the overlay never picks up a rebuild that lands after it opened. Pre-existing, and the prose in `AGENTS.md` and `README.md` currently describes a mechanism the code does not have. A fix has to preserve selection by window ID, the query, and the frozen context.
- **#22** — the one axis of #6 with no data behind it: the index holds windows, not applications.
- "Most recently opened" loses its ordering across a Space round trip, because `MRUTracker.retain` prunes bookkeeping for windows it cannot see. Documented rather than changed: recently-*used* already behaves identically, and making one of the two differ would be the worse wart.

## Validation

| Check | Result |
|---|---|
| `swift build -c release` | Clean, no warnings |
| `swift test` | **88 tests, 8 suites** (66 before this round, 42 before the branch) |
| `bash scripts/build-app.sh` | Bundles and signs |
| `openswitchr-diag --filters` | Every window claimed by a display, on a four-display layout with three displays above the primary |

**`--probe-app` could not be re-run conclusively.** It now fails on this machine for both this branch **and** the parent commit, identically. `openswitchr-diag` reports `Linked to an accessibility element: 0/25` with cold rebuilds of 1.1–1.3 s against ~240 ms earlier the same day: accessibility linking is dead machine-wide, so no window can be raised per-window and the Dock's own accessibility tree cannot be read. That is an environment condition, not a property of this change — bisecting to the parent commit reproduces it exactly. The last valid end-to-end probe, on the first commit of this branch, passed: overlay appeared, system switcher suppressed, focus moved, and the same Dock icon hovered twice with both passes appearing and hiding.

Worth re-running once accessibility is healthy again.

**Still unverified, stated plainly:** the Settings pickers are unclicked, and the instant-switch path is not covered by `--probe-app`, which hovers the same icon twice with nothing on screen in between and so never moves between icons while a panel is up.


---

# Follow-up: a report that turned out to be for another project

Two bugs were reported after installing the build — a panel disappearing on its own, and a "drop zone" being far too small. They were then identified as belonging to a different repository. This app has no pin and no drop zone, which was the clue I should have taken seriously before writing code.

What that produced here, and what happened to it:

- **A widened Dock hover region: reverted.** It changed user-facing behaviour with no defect behind it, and the justification I wrote for it was arithmetically wrong on top of that — the Dock item is generous by 4 points and the panel by 6 against a gap of 8, so the two already overlap by two points. There was no dead strip to close.
- **A commit guard using `CGEventSource.flagsState`: reverted.** It sounds right and is wrong. With it the overlay never closes at all, because the flags state still reports the modifier down at the moment the release arrives. The probe caught it on the first run.
- **An issue filed for the vanishing overlay: closed** as not applicable (#25), with the flags-state dead end recorded there so the idea does not get retried.

Two things were kept, because they stand on their own regardless of where the report came from:

- **The probe now holds the modifier for four seconds and asserts the overlay is still on screen**, and moves the pointer onto the Dock mid-hold to prove a preview appearing beside it does not take it away. It used to press and release within 250 ms — an overlay that appears and then gives up passed every check this project had. That is a genuine hole in the only test that exercises the shipping app.
- **`screenRect(of:)`**, because the Dock-item coordinate flip was written out twice and two copies of a flip are how they stop agreeing.

Also filed: **#26**, because the probe's focus check compares an app-name-plus-title string, so a correct switch between two identically titled windows of one application reads as a failure. It flipped between pass and fail on the same build minutes apart and caused two mis-diagnoses in one session.

## Validation

`swift build -c release` clean · `swift test` 88 tests · bundle signed · `--probe-app` against the installed release build:

```
Switcher overlay
  Appeared in 82 ms (1332x607)
  System app switcher: suppressed.
  Held for 4 s: still on screen.
  Survived the pointer reaching the Dock during the hold.
  On release: closed
  Focus: GitHub Copilot — GitHub Copilot -> Finder — img
  Focus moved.

Dock hover preview
  Hover 1 of "Finder".  appeared in 5 ms    on exit: hidden
  Hover 2 of "Finder".  appeared in 36 ms   on exit: hidden
```

The earlier inability to run this at all was an accessibility outage on the machine, since recovered: linking is back to 28/28 with 443 ms cold rebuilds.
