### PR TITLE
Build on the SDK the release is actually produced with

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,17 @@ permissions:
 
 jobs:
   build-and-test:
-    name: Build and test
-    runs-on: macos-latest
+    name: Build and test (${{ matrix.runner }})
+    # macos-15 is not redundant with macos-latest: it is the SDK the release is
+    # actually built on. The broker builds every published artifact on macos-15,
+    # and a Swift 6 concurrency error that the macOS 26 SDK annotates away is a
+    # hard error there. Testing only macos-latest let a green CI hand the broker
+    # a tree that could not compile, which is the worst place to find out.
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [macos-15, macos-latest]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The release build did not compile at all, while CI was green.** Published
+  builds are produced on `macos-15`, but CI only ever ran `macos-latest`. On the
+  macOS 26 SDK, `SCScreenshotManager.captureImage` is annotated such that
+  handing it a content filter built inside the `ThumbnailStore` actor is
+  accepted; on the macOS 15 SDK it is a `sending` violation and a hard error, so
+  the very first notarization request failed on a tree that had passed every
+  check. The capture now crosses the actor boundary as `Sendable` values in both
+  directions, and CI builds and tests on `macos-15` as well, so the toolchain
+  that produces releases can no longer go untested.
+
 - **Windows went unlinked right after launch, so the switcher raised the wrong
   one.** The accessibility timeout was 0.25 s per app. An app's first
   accessibility message is far more expensive than its later ones, and a cold

--- a/Sources/OpenSwitchrCore/ThumbnailStore.swift
+++ b/Sources/OpenSwitchrCore/ThumbnailStore.swift
@@ -167,15 +167,43 @@ public actor ThumbnailStore {
         let filter = SCContentFilter(desktopIndependentWindow: window)
 
         do {
-            let image = try await SCScreenshotManager.captureImage(
-                contentFilter: filter,
-                configuration: configuration
+            return try await Self.captureImage(
+                CaptureRequest(filter: filter, configuration: configuration)
             )
-            return ThumbnailImage(cgImage: image, capturedAt: Date())
         } catch {
             logger.debug("Capture failed for window \(windowID): \(error.localizedDescription)")
             return nil
         }
+    }
+
+    /// One capture's inputs, ready to leave the actor.
+    ///
+    /// Neither type is `Sendable`. Both are built immediately above, used
+    /// exactly once, and never read or mutated again on this side, so carrying
+    /// them across is safe in the way `@unchecked` is meant to assert.
+    private struct CaptureRequest: @unchecked Sendable {
+        let filter: SCContentFilter
+        let configuration: SCStreamConfiguration
+    }
+
+    /// Runs the capture outside the actor.
+    ///
+    /// `SCScreenshotManager.captureImage` is nonisolated, so calling it with a
+    /// filter built inside the actor sends a `self`-isolated, non-`Sendable`
+    /// value into another isolation domain. The macOS 26 SDK annotates its way
+    /// out of that; the macOS 15 SDK the release is built against does not, and
+    /// rejects it outright — which is why this has to cross the boundary as
+    /// `Sendable` values in both directions. The result is boxed in
+    /// ``ThumbnailImage`` for the same reason: `CGImage` is immutable but
+    /// unmarked.
+    private nonisolated static func captureImage(
+        _ request: CaptureRequest
+    ) async throws -> ThumbnailImage {
+        let image = try await SCScreenshotManager.captureImage(
+            contentFilter: request.filter,
+            configuration: request.configuration
+        )
+        return ThumbnailImage(cgImage: image, capturedAt: Date())
     }
 
     private func shareableWindow(id: CGWindowID) async -> SCWindow? {


### PR DESCRIPTION
The first notarization request for v0.1.0 failed: the broker builds on `macos-15` (Swift 6.1.2, macOS 15 SDK), where handing `SCScreenshotManager.captureImage` a content filter built inside the `ThumbnailStore` actor is a `sending` violation and a hard error. The macOS 26 SDK annotates its way out of it, so CI was green on a tree that could not compile.

- Cross the actor boundary as `Sendable` values in both directions, using the same `@unchecked` box pattern the file already uses for `SCShareableContent` and `CGImage`.
- Run CI on `macos-15` as well as `macos-latest`, so the toolchain that produces releases cannot go untested again.

Verified: both matrix jobs pass, and the `macos-15` job reports Swift 6.1.2 / `arm64-apple-macosx15.0` — the broker's toolchain.