### PR TITLE
Reassess against the quality standard, and close the gaps it names

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@ Resources/AppIcon.icns binary linguist-generated=true
 # Statistics and badge artifacts are rendered from an authoritative source and
 # committed. Same rule: regenerate, never edit.
 .github/stats/** linguist-generated=true
+.github/badges/** linguist-generated=true
 
 # Keep shell scripts and Swift sources on LF regardless of platform.
 *.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Generated, machine-owned paths. Do not hand-edit anything marked here.
+#
+# `Resources/AppIcon.icns` is rendered by `openswitchr-icon` from `WindowMark`
+# in `OpenSwitchrUI`, and `scripts/build-app.sh` re-runs the renderer on every
+# build. Editing the checked-in file is therefore pointless: the next build
+# overwrites it. It is tracked rather than ignored so a release can be built
+# without a rendering step, and marked here so reviews collapse it and agents
+# leave it alone.
+Resources/AppIcon.icns binary linguist-generated=true
+
+# Statistics and badge artifacts are rendered from an authoritative source and
+# committed. Same rule: regenerate, never edit.
+.github/stats/** linguist-generated=true
+
+# Keep shell scripts and Swift sources on LF regardless of platform.
+*.sh text eol=lf
+*.swift text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.plist text eol=lf
+*.entitlements text eol=lf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Every path in this repository is owned by its single maintainer.
+# See the "Support and maintenance" section of README.md for what that means
+# in practice.
+*       @trsdn

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Something in OpenSwitchr behaves differently from what it promises.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two things make a report about this app actionable, and both are easy to
+        leave out. Please repeat the gesture **at least twice** before filing:
+        several bugs here were invisible on a first attempt and only appeared on
+        the second, because the failure was stale state left behind by the first.
+        And please say which frontend you were in — the switcher overlay and the
+        Dock hover previews are separate surfaces over one shared index.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you saw, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: The exact gesture, and whether it fails on the first attempt or only on a repeat.
+      placeholder: |
+        1. Hold ⌘ and press Tab
+        2. …
+        3. Repeat — does it still fail?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface
+      options:
+        - Switcher overlay
+        - Dock hover preview
+        - Menu bar or Settings
+        - Diagnostics (openswitchr-diag)
+        - Build, install, or permissions
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: OpenSwitchr version
+      description: From the About tab in Settings, or the commit you built.
+    validations:
+      required: true
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version and hardware
+      placeholder: "macOS 26.6, Apple Silicon (M2)"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: permissions
+    attributes:
+      label: Permissions
+      description: The app degrades quietly without these, which produces convincing-looking bugs.
+      options:
+        - label: Accessibility is granted to OpenSwitchr
+        - label: Screen Recording is granted to OpenSwitchr
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics output
+      description: |
+        If you can, run `swift run openswitchr-diag` from a terminal that holds
+        the Accessibility permission and paste the output. The per-app
+        `CG` / `AX` / `LINKED` counts separate "the linking heuristic failed"
+        from "this app exposes no accessibility windows at all".
+      render: text
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Log output
+      description: |
+        Optional. `log stream --predicate 'subsystem == "com.openswitchr.app"' --level debug`
+        while reproducing. The app logs counts, pids, and error descriptions —
+        never window titles — so this is safe to paste.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/trsdn/OpenSwitchr/security/advisories/new
+    about: Report privately through a security advisory. Please do not open a public issue.
+  - name: Release procedure
+    url: https://github.com/trsdn/OpenSwitchr/blob/main/RELEASE_CHECKLIST.md
+    about: How a distributable, notarized build is produced.
+  - name: Architecture and design constraints
+    url: https://github.com/trsdn/OpenSwitchr/blob/main/AGENTS.md
+    about: Why the app is built the way it is, and which constraints are non-negotiable.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: Feature or change
+description: Propose something OpenSwitchr should do, or do differently.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two constraints decide most proposals here before anything else does, so
+        it is worth checking them first:
+
+        - **Current Space only.** Windows on other Spaces are deliberately out of
+          scope, because reaching them requires private SkyLight APIs.
+        - **No polling, and no work nobody can see.** Idle CPU must stay near
+          zero. Anything that needs a timer needs a reason the event-driven path
+          cannot serve.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What is awkward or missing today. Describe the situation, not the solution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should happen instead, and on which surface.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface
+      options:
+        - Switcher overlay
+        - Dock hover preview
+        - Both frontends
+        - Shared core (index, event bus, thumbnails, actions)
+        - Settings
+        - Build, release, or diagnostics
+    validations:
+      required: true
+
+  - type: textarea
+    id: cost
+    attributes:
+      label: Cost
+      description: |
+        What this would cost at idle and on the path that puts a frontend on
+        screen. An honest "I don't know" is fine; a missing answer is what makes
+        a proposal hard to schedule.
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: How it would be judged done
+      description: |
+        What someone would have to observe to believe it works. Note that unit
+        tests do not render and `openswitchr-diag` does not click controls, so
+        anything interactive in a tile needs a human to click it.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/badges/conformance.svg
+++ b/.github/badges/conformance.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="263" height="20" role="img" aria-label="trsdn standard: v1.5.1 - Needs work">
+  <title>trsdn standard: v1.5.1 - Needs work</title>
+  <rect width="114" height="20" rx="3" fill="#24292f"/>
+  <rect x="114" width="149" height="20" rx="3" fill="#bf8700"/>
+  <rect x="114" width="4" height="20" fill="#bf8700"/>
+  <g fill="#ffffff" font-family="DejaVu Sans,Verdana,sans-serif" font-size="11">
+    <text x="57.0" y="14" text-anchor="middle">trsdn standard</text>
+    <text x="188.5" y="14" text-anchor="middle">v1.5.1 - Needs work</text>
+  </g>
+</svg>

--- a/.github/conformance.yml
+++ b/.github/conformance.yml
@@ -1,0 +1,131 @@
+# Machine-readable result of assessing this repository against the trsdn
+# Repository Quality Standard. The reasoning behind every result that is not a
+# clean pass is in docs/self-assessment.md.
+#
+# Do not edit a result here without editing the evidence there. A record that
+# disagrees with its evidence is worse than no record.
+
+standard_version: "1.5.1"
+assessed_on: "2026-08-30"
+state: "Needs work"
+evidence: "docs/self-assessment.md"
+
+criteria:
+  # --- Baseline ---------------------------------------------------------
+  B01: pass
+  B02: pass
+  B03: pass
+  B04: pass
+  B05: pass
+  B06: pass
+  B07: pass
+  B08: pass
+  B09: pass
+  B10: pass
+  B11: pass
+  B12: pass
+  B13: partial
+
+  # --- Public Repositories ----------------------------------------------
+  P01: pass
+  P02: pass
+  P03: pass
+  P04: pass
+  P05: pass
+  P06: pass
+  P07: pass
+  P08: partial
+  P09: fail
+
+  # --- Software Repositories --------------------------------------------
+  S01: pass
+  S02: partial
+  S03: partial
+  S04: pass
+  S05: pass
+  S06: na
+  S07: pass
+  S08: pass
+  S09: pass
+  S10: pass
+
+  # --- Deployable Repositories (nothing is deployed) --------------------
+  D01: na
+  D02: na
+  D03: na
+  D04: na
+  D05: na
+  D06: na
+
+  # --- Package And Release Repositories ---------------------------------
+  R01: partial
+  R02: pass
+  R03: partial
+  R04: partial
+  R05: fail
+  R06: partial
+
+  # --- Product Identity --------------------------------------------------
+  I01: pass
+  I02: pass
+  I03: pass
+  I04: pass
+  I05: pass
+  I06: partial
+
+  # --- Documentation Repositories (the product is an app) ---------------
+  T01: na
+  T02: na
+  T03: na
+  T04: na
+  T05: na
+
+  # --- Published Sites (there is no site) --------------------------------
+  W01: na
+  W02: na
+  W03: na
+  W04: na
+  W05: na
+  W06: na
+  W07: na
+  W08: na
+
+  # --- Agent Readiness ---------------------------------------------------
+  G01: pass
+  G02: pass
+  G03: pass
+  G04: pass
+  G05: pass
+  G06: pass
+  G07: pass
+  G08: pass
+
+  # --- Language And Localization ----------------------------------------
+  L01: pass
+  L02: pass
+  L03: pass
+  L04: na
+  L05: na
+  L06: na
+  L07: pass
+
+  # --- Accessibility -----------------------------------------------------
+  X01: partial
+  X02: pass
+  X03: partial
+  X04: pass
+  X05: pass
+
+  # --- Data Protection And Privacy ---------------------------------------
+  Y01: pass
+  Y02: pass
+  Y03: pass
+  Y04: pass
+  Y05: pass
+  Y06: pass
+
+  # --- Archived Repositories (actively developed) ------------------------
+  A01: na
+  A02: na
+  A03: na
+  A04: na

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  # The Swift package has no dependencies, so there is nothing for a `swift`
+  # ecosystem entry to update. The pinned action versions in the workflows do
+  # age, and they are the only third-party code this repository executes.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      include: scope
+    labels:
+      - dependencies

--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,0 +1,22 @@
+# Repository-scoped configuration for GitHub Copilot agents.
+# Reference: https://docs.github.com/copilot/reference/github-copilot-app-reference/repository-configuration
+#
+# The authoritative instructions live in AGENTS.md at the repository root,
+# which is tool-neutral and read by every agent that works here. Nothing in
+# this file may restate a rule from AGENTS.md; it points at it instead, so the
+# two cannot drift apart.
+
+version: 1
+
+instructions:
+  - path: AGENTS.md
+
+setup:
+  # No dependencies to install: the Swift package has none, and everything the
+  # validation command needs ships with macOS.
+  steps: []
+
+validate:
+  # The single command an agent runs before proposing a change.
+  - name: Build, test, and check metadata
+    run: bash scripts/check.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Test
         run: swift test
 
+      # Catches an Info.plist version typed by hand that has drifted away from
+      # CHANGELOG.md, and identity keys AboutView reads back at runtime. Same
+      # script an agent or a laptop runs, so there is one definition of the
+      # check rather than two that disagree.
+      - name: Check bundle metadata consistency
+        run: bash scripts/check.sh --metadata-only
+
       # The bundle build catches Info.plist and entitlements mistakes that a
       # plain `swift build` cannot see. Signing is unavailable on CI without
       # the release secrets, so only the unsigned packaging steps run here.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,25 @@
+name: Conformance
+
+# Validates .github/conformance.yml against the catalog for the standard
+# version the record names, and fails when the record is incomplete, uses a
+# result outside the vocabulary, or has aged past the review cadence.
+#
+# Like every other workflow here, this uses no secret, no environment, and no
+# write permission.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # Weekly, so an ageing record turns the check red on its own rather than
+    # waiting for someone to push.
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    uses: trsdn/.github/.github/workflows/conformance.yml@main

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,25 @@
+name: Markdown
+
+# The documentation in this repository carries real design rationale, so it is
+# held to the same "warnings are findings" rule the Swift build is. Rules are
+# configured in .markdownlint.jsonc, which mirrors trsdn/.github.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint Markdown
+        run: npx --yes markdownlint-cli2@0.18.1 "**/*.md"

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,14 @@
+// Mirrors the configuration published in trsdn/.github, so markdown here is
+// held to the same rules as every other repository assessed against the
+// Repository Quality Standard.
+{
+  "default": true,
+  // Prose is hard-wrapped by hand at a readable width rather than a fixed one.
+  "MD013": false,
+  // Keep a Changelog repeats "### Added" under each release heading by design.
+  "MD024": {
+    "siblings_only": true
+  },
+  // Inline HTML is needed for the light/dark <picture> element in the README.
+  "MD033": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,22 @@ Guidance for AI coding agents working in this repository.
 
 ## Build & install
 
+**Validate every change with one command before proposing it:**
+
+```bash
+bash scripts/check.sh
+```
+
+That is the authoritative gate. It builds with warnings as errors, runs the
+tests, lints the markdown, and asserts that the version in `Info.plist` still
+agrees with `CHANGELOG.md` and that the minimum macOS version agrees across
+`Package.swift`, `scripts/build-app.sh`, and the README badge. It needs no
+signing identity, no permissions, and no network, so it behaves identically on a
+laptop, in CI, and for an agent. `--metadata-only` skips the build and tests,
+which is what CI calls after it has already built.
+
+The individual pieces, when you need one of them on its own:
+
 ```bash
 # Compile check
 swift build -c release
@@ -30,6 +46,95 @@ swift run openswitchr-diag --probe-app
 There is no Xcode project. Everything goes through SwiftPM; the app bundle is
 assembled manually in `scripts/build-app.sh`.
 
+`scripts/check.sh` deliberately does **not** run `openswitchr-diag`. A green
+`check.sh` says the core compiles and its logic holds; it says nothing about
+whether the app wired any of it up. See "Verifying the app, not just the core".
+
+## Forbidden and high-risk operations
+
+None of the following is ever part of a normal change here. Do not perform any
+of them on your own initiative; ask first, and say plainly that you are asking
+because the operation is on this list.
+
+**Never, under any circumstances:**
+
+- **Add an Apple credential, certificate, provisioning profile, or App Store
+  Connect key to this repository**, in any form, including a base64 blob in a
+  workflow. Releases exist specifically so this never has to happen — see
+  "Releases go through the broker".
+- **Add a secret, an environment, or a write permission to any workflow here.**
+  Every workflow in `.github/workflows` runs with `contents: read` and no
+  secrets, and that is the property that makes this repository safe to build
+  from. A feature that needs write access to the repository is not worth it.
+- **Commit anything into `.release.env`.** It is git-ignored and holds a local
+  signing identity. `.release.env.example` is the only version that is tracked.
+- **Rewrite published history.** No `git rebase`, `commit --amend`, or
+  `push --force` against `main` or any branch that already has a pull request.
+  A ruleset blocks force pushes to `main`, but branches are on trust.
+- **Move or delete a tag that has been pushed.** A release tag is an input to
+  the notarization broker; repointing one silently changes what was published.
+- **Weaken the signing check in `build-app.sh`.** It aborts on an ad-hoc
+  signature on purpose: TCC permissions are bound to the code signature, and an
+  ad-hoc build silently loses every grant the user has given.
+
+**Ask before doing:**
+
+- **Changing the bundle identifier, executable name, bundle layout,
+  architecture, entitlements, or minimum macOS version.** All of these are
+  mirrored in the broker's `profiles/apps.json`, and a change here without a
+  reviewed pull request there fails release preflight. See
+  `RELEASE_CHECKLIST.md`.
+- **Renaming the product.** Use `bash scripts/rename-product.sh <NewName>`
+  rather than editing names by hand, and read "The name" first — plain
+  "OpenSwitch" is taken and must not reappear anywhere.
+- **Changing repository settings**: visibility, branch protection, required
+  checks, topics, or the security features. These are recorded in
+  `.github/conformance.yml`, so changing one silently makes the record wrong.
+- **Publishing a release**, or triggering the broker.
+- **Deleting a branch or a worktree that is not yours.**
+- **Adding a third-party dependency.** The Swift package deliberately has none,
+  which is why a clean checkout builds with no network access.
+- **Adding anything that opens a network connection.** The app makes none, and
+  the README states that as a guarantee to the user.
+- **Loosening a permission or a usage-description string in `Info.plist`.**
+
+## Generated and machine-owned paths
+
+Do not hand-edit these. They are marked `linguist-generated` in
+`.gitattributes`, and each is rewritten from its source on the next build.
+
+| Path | Produced by | Source of truth |
+| --- | --- | --- |
+| `Resources/AppIcon.icns` | `swift run openswitchr-icon`, re-run by `scripts/build-app.sh` on every build | `WindowMark` in `Sources/OpenSwitchrUI/WindowMark.swift` |
+| `.build/` | SwiftPM | — (git-ignored) |
+| `dist/` | `scripts/make_dmg.sh` | — (git-ignored) |
+
+`AppIcon.icns` is tracked rather than ignored so a release can be built without
+a rendering step. That makes it look editable, which it is not: change
+`WindowMark` and rebuild.
+
+Two paths are hand-maintained but are *derived* facts, and a check fails when
+they drift — treat them as generated even though they are not. The version in
+`Info.plist` must match the newest release heading in `CHANGELOG.md`, and the
+minimum macOS version must match `Package.swift` and the README badge. Both are
+asserted by `scripts/check.sh`.
+
+## Review expectation for agent-authored changes
+
+Every commit an agent makes carries a `Co-authored-by` trailer, so authorship
+stays visible in `git log` and in the blame view. Beyond attribution:
+
+- **Everything reaches `main` through a pull request.** A ruleset requires one,
+  and requires the CI, matrix, and secret-scan checks to pass. Nothing is
+  pushed straight to `main`, including by the maintainer.
+- **A change is described by what it fixes and why, not by what it touches.**
+  The commit messages and changelog entries in this repository record the
+  measurement or the trap that motivated the change. Match that.
+- **Say what you did not verify.** Unit tests do not render, `openswitchr-diag`
+  does not click controls, and the panels expose no content window to UI
+  automation. A new control in a tile is unverified until a human clicks it —
+  write that down rather than implying it was tested.
+
 ## Releases go through the broker
 
 Distributable builds come from `trsdn/macos-notarization-broker`. Apple
@@ -51,7 +156,7 @@ sit on one shared foundation, which is the entire point of the project: the
 window index, the event bus, the thumbnail cache, and the window actions exist
 **once**.
 
-```
+```text
 Sources/
 ├── OpenSwitchrCore/   Shared foundation. No UI, no frontend assumptions.
 ├── OpenSwitchrUI/     SwiftUI views + non-activating panel infrastructure.
@@ -290,114 +395,26 @@ editing names by hand.
 
 ## Repository quality standard
 
-Assessed against the [`trsdn/.github`](https://github.com/trsdn/.github)
-Repository Quality Standard, version 1.3.3, on 2026-08-26. State: **Needs
-work** — high-priority gaps exist, but the repository is usable.
+This repository is assessed against the
+[trsdn Repository Quality Standard](https://github.com/trsdn/.github/blob/main/docs/repository-quality-standard.md).
 
-The standard keeps its result in `.github/conformance.yml` and its narrative in
-`docs/self-assessment.md`. This repository has neither, which is `B11` failing;
-until they exist, this section is the record. Every line below is evidence from
-the GitHub API, a workflow run, or a file in the tree — nothing is assumed.
+The result lives in exactly two places, and this section is deliberately not a
+third:
 
-### The finding that outranks the rest
+- `.github/conformance.yml` — the machine-readable record: which version of the
+  standard, when it was assessed, the overall state, and a result for every
+  criterion in the catalog.
+- `docs/self-assessment.md` — the evidence: what was observed for each
+  criterion that is not a clean pass, and what would have to change.
 
-`main` holds two files: `README.md` and `.gitignore`. Everything this document
-describes — the sources, the tests, the CI workflows, `LICENSE`, this file —
-lives in an unmerged branch.
+A scheduled workflow re-validates the record against the published catalog, so
+an incomplete record, a retired criterion, or an assessment that has aged past
+the review cadence turns the check red without anyone remembering to look.
 
-Most of the standard reads the default branch or the repository settings, so a
-stub default branch fails criteria the work already satisfies. GitHub reports
-`license: null` for a public repository, which is the "ambiguous public
-licensing" case the standard names as high-priority, and it is why `B03` and
-`P01` fail despite `LICENSE` existing three commits away. Merging is the single
-change that moves the most criteria.
-
-### Profiles
-
-| Profile | Applies | Why |
-| --- | --- | --- |
-| Baseline | Yes | Always |
-| Public | Yes | Public visibility |
-| Software | Yes | Ships a Swift package and an app bundle |
-| Product Identity | Yes | Builds a signed `.app` a user installs |
-| Package And Release | Yes | Releases are intended, via the notarization broker |
-| Agent Readiness | Yes | This file exists and agents work here |
-| Language, Accessibility, Privacy | Yes | A shipping user interface |
-| Deployable | No | Nothing is deployed to any environment |
-| Documentation | No | The product is software; docs support it |
-| Archived | No | Actively developed |
-
-### Gaps
-
-| ID | Result | Observed |
-| --- | --- | --- |
-| `B03`, `P01` | fail | No licence on the default branch. `LICENSE` is only in the unmerged branch, so GitHub detects none. |
-| `B06`, `S09` | fail | `main` is unprotected: the API answers `Branch not protected`, there are no rulesets, and CI is not a required check. |
-| `B11` | fail | No `.github/conformance.yml`. |
-| `B12`, `P07` | fail | No topics at all, so the `trsdn-standard` set does not include this repository. No homepage. |
-| `P03` | partial | `SECURITY.md` is inherited from `trsdn/.github`, but private vulnerability reporting is disabled (`{"enabled": false}`). |
-| `P04` | partial | The pull-request template is inherited; the community profile reports `issue_template: null`, so the issue forms are not applied. |
-| `P08`, `P09` | fail | No status badges and no repository activity card in the README. |
-| `S03` | partial | Warnings are errors in CI, which is real static analysis, but no formatter or linter is configured. |
-| `S04` | partial | One job on `macos-latest`. The label is unpinned, so the macOS version under test moves without a commit while the README promises macOS 15+. |
-| `S05` | partial | `secret-scan.yml` runs on every pull request and passes, but GitHub secret scanning and push protection are both disabled. |
-| `S08` | fail | No `dependabot.yml` and Dependabot security updates disabled. The Swift package has no dependencies, but the workflows pin `actions/checkout@v4`, which does age. |
-| `I02`, `I03` | fail | The bundle carries no repository URL, no issue tracker URL, no licence identifier, and no copyright holder. `LICENSE` is not copied into the app. |
-| `I04` | partial | The About tab shows the version and links to the repository; it does not link an issue tracker. |
-| `I06` | fail | `CFBundleVersion` and `CFBundleShortVersionString` are typed into `Info.plist` by hand. Nothing derives them from a tag. |
-| `G03` | fail | Nothing here names forbidden or high-risk operations: history rewriting, force pushes, secret handling, releases, tag moves, repository settings. |
-| `G05` | partial | Validation is several commands. The standard asks for one that an agent can run before proposing a change. |
-| `G06` | fail | No path is marked as generated. `Resources/AppIcon.icns` is produced by `openswitchr-icon` and rewritten by `build-app.sh` on every build, and nothing says so. There is no `.gitattributes`. |
-| `G07` | partial | Agent commits carry `Co-authored-by` trailers, but no review expectation is written down. |
-| `G08` | fail | No `.github/github-app.yml`. |
-| `L01`, `L03` | partial / fail | Every surface is English; nothing declares English as the primary language, and localization support is never stated as English-only. |
-| `X01` | partial | The switcher is fully keyboard-driven. Dock hover previews are reachable only by pointer, which is inherent to hovering a Dock icon but is not written down anywhere. |
-| `X03` | partial | Meaning never rests on colour alone — the quit control is red *and* a distinct glyph in the opposite corner — but behaviour under platform text-size settings is unverified. |
-| `X05` | fail | Known accessibility limits are not stated. |
-| `Y01`, `Y04` | fail | The README never says the app collects nothing and transmits nothing, and never says preferences live in `UserDefaults` under `com.openswitchr.app`. The explicit "none" case still has to be written. |
-| `Y02` | partial | The app opens no outbound connection. Nothing documents that. |
-| `R03`, `R05` | fail | No release workflow, no release, no smoke test of a built artifact in a clean environment. |
-| `B04` | partial | `.gitignore` covers build output, `dist/`, and `.release.env`; the generated `AppIcon.icns` is tracked without being marked. |
-| `B09`, `B10` | partial | Visibility and archive state are intentional; there is no `CODEOWNERS`, and the README states "Early" without naming an owner or a maintenance commitment. |
-| `P05`, `P06` | partial | The README covers install, build, and compatibility, but not configuration, security, or support. The community profile sits at 85 %. |
-| `S02` | partial | 42 tests, all pure logic. Everything touching accessibility or the window server is covered only by `openswitchr-diag`, which is manual and absent from CI — as the section above already admits. |
-| `T02` | partial | Nothing validates the markdown. Against the standard's own `.markdownlint.jsonc` this repository reports 26 issues: 24 table-separator spacings, one fenced block without a language, and one duplicate `### Added` heading in `CHANGELOG.md`. All trivial, none currently visible to anyone. |
-
-### Notable passes
-
-- `B05`, `S01`, `S10` — a clean checkout builds and tests with documented
-  commands, no external dependencies, and CI proves it on every push.
-- `S07` — verified by reading every logging call: no window title, no personal
-  data, only counts, pids, and error descriptions.
-- `X02` — tiles and the menu bar item carry accessibility labels.
-- `X04` — `openswitchr-diag` emits plain text with no colour and no Unicode
-  decoration, so its output survives any pipe or log.
-- `I01`, `I05` — the bundle carries its name and version, and embeds an icon
-  generated from the same `WindowMark` the menu bar draws.
-- `G01`, `G02` — this file exists, and its build, run, and validation commands
-  were each executed rather than trusted.
-- `B08`, `R02` — `CHANGELOG.md` follows Keep a Changelog and states the
-  versioning policy.
-
-### Not applicable
-
-- **Deployable `D01`-`D06`.** Nothing is deployed. There is no environment.
-- **Documentation `T01`-`T05`.** The product is an app.
-- **`L04`-`L06`.** English only; no string catalogs exist to be validated.
-- **`S06`.** No runtime configuration beyond user preferences.
-- **`Y05`, `Y06`.** No third-party service receives anything, and thumbnails are
-  held in memory under a byte budget, so nothing outlives a session.
-- **Archived `A01`-`A04`.** Actively developed.
-
-### Order of remediation
-
-1. Merge, so the default branch stops contradicting the repository.
-2. Enable secret scanning, push protection, and private vulnerability
-   reporting; protect `main` and require CI. These are settings, not code.
-3. Add `.github/conformance.yml` and the `trsdn-standard` topic, so the result
-   is recorded and discoverable.
-4. Add the `G03` and `G06` sections to this file — forbidden operations, and
-   the generated paths — since both describe rules an agent is expected to
-   follow and currently cannot read.
-5. State the "none" cases: no data collected, no outbound connections, English
-   only, and the known accessibility limits.
+An earlier version of this file carried the whole assessment inline. It went
+stale within days — it described a default branch holding two files, which
+stopped being true the moment the work was merged, and it assessed against a
+version of the standard that has since moved on twice. That is exactly the
+failure `B13` exists to prevent: a fact with two homes has no home. If you
+change something that affects a criterion, update the record and the assessment,
+not this paragraph.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,12 +106,24 @@ Do not hand-edit these. They are marked `linguist-generated` in
 | Path | Produced by | Source of truth |
 | --- | --- | --- |
 | `Resources/AppIcon.icns` | `swift run openswitchr-icon`, re-run by `scripts/build-app.sh` on every build | `WindowMark` in `Sources/OpenSwitchrUI/WindowMark.swift` |
+| `.github/badges/conformance.svg` | `scripts/conformance.py` in `trsdn/.github` | `.github/conformance.yml` |
 | `.build/` | SwiftPM | — (git-ignored) |
 | `dist/` | `scripts/make_dmg.sh` | — (git-ignored) |
 
 `AppIcon.icns` is tracked rather than ignored so a release can be built without
 a rendering step. That makes it look editable, which it is not: change
 `WindowMark` and rebuild.
+
+The conformance badge is committed for the same reason the standard requires it
+to be: an image fetched from a rendering service at read time observes every
+reader, and cannot be held to the record. It is regenerated with
+
+```bash
+python3 scripts/conformance.py --repository /path/to/OpenSwitchr
+```
+
+run from a checkout of `trsdn/.github`. The `Conformance` workflow fails when
+the committed badge does not match the record, so it cannot quietly drift.
 
 Two paths are hand-maintained but are *derived* facts, and a check fails when
 they drift — treat them as generated even though they are not. The version in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Repository conformance record at `.github/conformance.yml`, assessed against
   version 1.5.1 of the trsdn Repository Quality Standard, with the reasoning
-  behind every result in `docs/self-assessment.md`. A scheduled workflow
-  re-validates it, so an assessment that ages past the review cadence turns the
-  check red on its own.
+  behind every result in `docs/self-assessment.md` and the badge rendered from
+  the record into `.github/badges/conformance.svg`. A scheduled workflow
+  re-validates both, so a record that drifts from its badge, or an assessment
+  that ages past the review cadence, turns the check red on its own.
 - `scripts/check.sh`, the single command that validates a change before it is
   proposed: build with warnings as errors, tests, markdown lint, and the bundle
   metadata checks below. It needs no signing identity, no permissions, and no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Repository conformance record at `.github/conformance.yml`, assessed against
+  version 1.5.1 of the trsdn Repository Quality Standard, with the reasoning
+  behind every result in `docs/self-assessment.md`. A scheduled workflow
+  re-validates it, so an assessment that ages past the review cadence turns the
+  check red on its own.
+- `scripts/check.sh`, the single command that validates a change before it is
+  proposed: build with warnings as errors, tests, markdown lint, and the bundle
+  metadata checks below. It needs no signing identity, no permissions, and no
+  network, so it behaves the same on a laptop, in CI, and for an agent.
+- Drift guards for the three facts nothing used to compare. The version in
+  `Info.plist` is checked against the newest release heading in this file, and
+  the minimum macOS version is checked across `Package.swift`,
+  `scripts/build-app.sh`, and the README badge. All of them had been maintained
+  by hand in parallel.
+- Product identity in the bundle: repository URL, issue tracker URL, licence
+  identifier, and copyright holder as `Info.plist` keys, plus the licence text
+  copied into `Contents/Resources`. The About tab now reads its links back out
+  of the bundle rather than hardcoding them a second time, so the shipped
+  metadata and what the user sees cannot disagree.
+- Issue forms for bug reports and proposals, a `CODEOWNERS` file, a Dependabot
+  configuration for the pinned action versions, `.github/github-app.yml`, and a
+  markdown lint workflow.
+- `.gitattributes`, marking `Resources/AppIcon.icns` as generated. It is
+  rewritten by every build, so hand-editing it accomplishes nothing.
+- README sections stating the cases that were previously only implicit: the app
+  collects nothing and opens no outbound connection, preferences live in
+  `UserDefaults` under `com.openswitchr.app` and how to read or delete them,
+  the project is English-only, and which accessibility limitations are known.
+- `AGENTS.md` now names the operations an agent must not perform, the paths that
+  are generated, and the review expectation for agent-authored changes.
+
+### Changed
+
+- `main` is protected: pull requests are required, the three CI checks must
+  pass, and force pushes and branch deletion are blocked. Secret scanning, push
+  protection, Dependabot security updates, and private vulnerability reporting
+  are enabled.
+- The repository quality section of `AGENTS.md` was reassessed. It had described
+  a default branch holding two files, which stopped being true when the work was
+  merged, and it assessed against version 1.3.3 of a standard now at 1.5.1.
+
+### Fixed
+
+- The two sibling `### Added` headings under `0.1.0` in this file are merged
+  into one, which is both a lint failure and genuinely confusing to read.
+
 ## [0.1.0] - 2026-08-30
 
 ### Added
@@ -40,6 +88,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   they put destructive targets a few pixels from the one that focuses a window;
   close sits top left and quit top right, in opposite corners rather than side
   by side, because only one of the two can be undone.
+- Release process via `trsdn/macos-notarization-broker`, documented in
+  `RELEASE_CHECKLIST.md`. Apple credentials never enter this repository; the
+  broker builds from a pinned commit and signs with its own code.
+- `scripts/make_dmg.sh` for local, explicitly unnotarized test packaging.
+- GitHub Actions: `ci.yml` builds with warnings-as-errors and runs the tests,
+  and `secret-scan.yml` guards against committed credentials. Neither uses a
+  secret, an environment, or write permissions.
+- An app icon, and a menu bar glyph drawn from the same geometry. `WindowMark`
+  in `OpenSwitchrUI` owns the two overlapping windows; `openswitchr-icon`
+  renders `Resources/AppIcon.icns` from it and `build-app.sh` re-runs on every
+  build, so the icon cannot fall behind the glyph. The icon takes the filled
+  weight and the menu bar the outlined one, because solid art that carries a
+  1024 pt icon collapses into a blob at 15 pt.
 
 ### Performance
 
@@ -68,22 +129,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Recreating it on every render made the overlay cost ~50 ms to appear and
   repeated the same work on every selection change; it now appears in
   ~21–24 ms.
-
-### Added
-
-- Release process via `trsdn/macos-notarization-broker`, documented in
-  `RELEASE_CHECKLIST.md`. Apple credentials never enter this repository; the
-  broker builds from a pinned commit and signs with its own code.
-- `scripts/make_dmg.sh` for local, explicitly unnotarized test packaging.
-- GitHub Actions: `ci.yml` builds with warnings-as-errors and runs the tests,
-  and `secret-scan.yml` guards against committed credentials. Neither uses a
-  secret, an environment, or write permissions.
-- An app icon, and a menu bar glyph drawn from the same geometry. `WindowMark`
-  in `OpenSwitchrUI` owns the two overlapping windows; `openswitchr-icon`
-  renders `Resources/AppIcon.icns` from it and `build-app.sh` re-runs on every
-  build, so the icon cannot fall behind the glyph. The icon takes the filled
-  weight and the menu bar the outlined one, because solid art that carries a
-  1024 pt icon collapses into a blob at 15 pt.
 
 ### Changed
 

--- a/Info.plist
+++ b/Info.plist
@@ -10,6 +10,18 @@
     <string>0.1.0</string>
     <key>CFBundleShortVersionString</key>
     <string>0.1.0</string>
+    <!-- Identity the running app reads back rather than hardcoding a second
+         time: AboutView renders its links from these keys, so the bundle and
+         the About tab cannot disagree. `scripts/check.sh` asserts that the two
+         version strings match the newest release heading in CHANGELOG.md. -->
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2026 Torsten Mahr. Released under the MIT License.</string>
+    <key>OSWLicenseIdentifier</key>
+    <string>MIT</string>
+    <key>OSWRepositoryURL</key>
+    <string>https://github.com/trsdn/OpenSwitchr</string>
+    <key>OSWIssueTrackerURL</key>
+    <string>https://github.com/trsdn/OpenSwitchr/issues</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSAccessibilityUsageDescription</key>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![macOS 15+](https://img.shields.io/badge/macOS-15%2B-blue)](#requirements)
 [![CI](https://github.com/trsdn/OpenSwitchr/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/trsdn/OpenSwitchr/actions/workflows/ci.yml)
 [![Latest tag](https://img.shields.io/github/v/tag/trsdn/OpenSwitchr?label=release)](https://github.com/trsdn/OpenSwitchr/releases)
-[![Conformance](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftrsdn%2FOpenSwitchr%2Fmain%2F.github%2Fconformance.yml&query=%24.state&label=conformance)](.github/conformance.yml)
+[![Conformance](.github/badges/conformance.svg)](.github/conformance.yml)
 
 **One app instead of two.** Dock hover previews and an Alt-Tab style window
 switcher, built on a single shared window index.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # OpenSwitchr
 
+[![License: MIT](https://img.shields.io/github/license/trsdn/OpenSwitchr?label=license)](LICENSE)
+[![macOS 15+](https://img.shields.io/badge/macOS-15%2B-blue)](#requirements)
+[![CI](https://github.com/trsdn/OpenSwitchr/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/trsdn/OpenSwitchr/actions/workflows/ci.yml)
+[![Latest tag](https://img.shields.io/github/v/tag/trsdn/OpenSwitchr?label=release)](https://github.com/trsdn/OpenSwitchr/releases)
+[![Conformance](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftrsdn%2FOpenSwitchr%2Fmain%2F.github%2Fconformance.yml&query=%24.state&label=conformance)](.github/conformance.yml)
+
 **One app instead of two.** Dock hover previews and an Alt-Tab style window
 switcher, built on a single shared window index.
 
@@ -31,8 +37,9 @@ overlay are thin readers on top.
 
 ## Status
 
-Early. The core is implemented and measured; the release pipeline is not built
-yet. There is no published binary.
+Early, and actively developed. The core is implemented and measured, `v0.1.0`
+is tagged, and releases run through the notarization broker. There is no
+published binary yet, so installing means building from source.
 
 ## Requirements
 
@@ -46,17 +53,43 @@ yet. There is no published binary.
 ```bash
 swift build -c release          # compile
 swift test                      # pure-logic tests
+bash scripts/check.sh           # build, tests, markdown, and bundle metadata
 bash scripts/build-app.sh       # assemble and sign .build/release/OpenSwitchr.app
 
 cp -R .build/release/OpenSwitchr.app /Applications/
 open /Applications/OpenSwitchr.app
 ```
 
+`scripts/check.sh` is the single validation command: it builds with warnings as
+errors, runs the tests, lints the markdown, and asserts that the version in
+`Info.plist` still agrees with `CHANGELOG.md`. It needs no signing identity, no
+permissions, and no network, so it runs the same on a laptop, in CI, and for an
+agent.
+
 There is no Xcode project; the app bundle is assembled by the build script.
 The app icon is generated rather than checked in as an opaque binary —
 `swift run openswitchr-icon` renders `Resources/AppIcon.icns` from the same
 `WindowMark` the menu bar glyph is drawn from, and `build-app.sh` re-runs it on
-every build so the two cannot drift apart.
+every build so the two cannot drift apart. That file is marked
+`linguist-generated` in `.gitattributes`; editing it by hand accomplishes
+nothing, because the next build overwrites it.
+
+## Configuration
+
+Everything is configured from the menu bar item → **Settings**. There is no
+configuration file and no environment variable.
+
+Preferences are stored in `UserDefaults` under the `com.openswitchr.app` suite,
+which on disk is `~/Library/Preferences/com.openswitchr.app.plist`. To inspect
+or reset them:
+
+```bash
+defaults read com.openswitchr.app             # show every stored preference
+defaults delete com.openswitchr.app <key>     # restore one registered default
+defaults delete com.openswitchr.app           # restore all of them
+```
+
+Every setting takes effect immediately; none of them requires a relaunch.
 
 ## Release
 
@@ -180,6 +213,89 @@ otherwise the tile of an already-closed window would stay on screen. Quitting
 deliberately does *not* prune tiles: `terminate()` is a request, and an app with
 unsaved work may put up a dialog and stay. The panel dismisses instead, which
 also stops it covering that dialog.
+
+## Privacy
+
+OpenSwitchr collects nothing and transmits nothing. Stated explicitly, because
+"no privacy policy" and "no data collection" look identical from the outside:
+
+- **No outbound connections.** The app opens no network connection of any kind.
+  There is no update check, no license check, and no remote configuration.
+- **No telemetry, analytics, or crash reporting.** None is present, so there is
+  nothing to opt out of.
+- **No third-party services.** No service, and no AI provider, receives anything
+  from this app. It has no account and no identifier.
+- **Window titles never leave the process.** They are read to render and filter
+  tiles. The unified log deliberately records only counts, pids, and error
+  descriptions, so a log someone pastes into an issue cannot expose what they
+  had open.
+- **Thumbnails live in memory only.** ScreenCaptureKit images are held in an LRU
+  cache under a hard byte budget and are never written to disk. They do not
+  outlive the process; quitting the app is the whole of the deletion story.
+- **The only thing stored on disk is your preferences**, in `UserDefaults` under
+  `com.openswitchr.app`. See [Configuration](#configuration) for how to read,
+  export, or delete them.
+
+Two permissions are required, and both stay local: **Accessibility** to
+enumerate windows, receive the hotkey, and raise a window; **Screen Recording**
+to capture thumbnails. Both are revocable in System Settings → Privacy &
+Security, and the app degrades to icon-only tiles without the second.
+
+One caveat that is about this page rather than the app: viewing this README on
+github.com loads the badge images at the top from `img.shields.io`, which
+observes the request the way any remote image does. Nothing in the app itself
+contacts that host, or any other.
+
+## Language
+
+English only. Every user-facing string, every command-line message, and every
+document in this repository is English, and there is no localization
+infrastructure — no string catalogs, no `.lproj` directories, no translation
+pipeline. This is a declared state rather than an oversight; adding a language
+is tracked in [#5](https://github.com/trsdn/OpenSwitchr/issues/5).
+
+## Accessibility
+
+What works, and what does not:
+
+- **The switcher is fully keyboard-driven.** Hold the modifier, `Tab` and
+  `⇧-Tab` move the selection, typing filters, `Escape` cancels, releasing the
+  modifier commits. The selected tile carries a visible indicator, and tiles
+  expose an accessible name and role to VoiceOver, as does the menu bar item.
+- **Meaning never rests on colour alone.** The quit control on a tile is red
+  *and* a distinct glyph in the opposite corner from the close control; a
+  minimized window is dimmed *and* explicitly marked.
+
+Known limitations, stated rather than left implicit:
+
+- **Dock hover previews are pointer-only.** They are triggered by the pointer
+  entering a Dock icon, so there is no keyboard route to them. This is inherent
+  to the gesture; the switcher overlay reaches every window without a pointer.
+- **Behaviour under enlarged platform text sizes is unverified.** Tiles size
+  themselves from the preview-size preference rather than from the text metrics,
+  so a large accessibility text size may clip a long window title.
+- **Reduced-motion and increased-contrast settings are not specifically
+  honoured.** The panels use the system material and standard SwiftUI controls,
+  so they inherit whatever those do, but nothing here was tested against those
+  settings.
+
+`openswitchr-diag` emits plain text with no colour and no Unicode decoration, so
+its output survives any pipe, log, or screen reader.
+
+## Support and maintenance
+
+Maintained by [@trsdn](https://github.com/trsdn) as a single-maintainer project,
+best-effort and in the open. There is no service-level commitment and no
+guaranteed response time.
+
+- **Bugs and proposals** → [issues](https://github.com/trsdn/OpenSwitchr/issues),
+  which offer a form for each. Please repeat a failing gesture twice before
+  filing; several bugs here only appeared on the second attempt.
+- **Security vulnerabilities** → report privately through
+  [a security advisory](https://github.com/trsdn/OpenSwitchr/security/advisories/new),
+  not a public issue.
+- **Why the code is shaped the way it is** → `AGENTS.md`, which records the
+  design constraints and the traps that produced them.
 
 ## Scope: current Space only
 

--- a/Sources/OpenSwitchr/AboutView.swift
+++ b/Sources/OpenSwitchr/AboutView.swift
@@ -3,9 +3,28 @@ import SwiftUI
 
 struct AboutView: View {
 
-    private var version: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+    /// Every value here is read back out of the bundle rather than written a
+    /// second time in Swift. `Info.plist` is the one home for the app's
+    /// identity, so the About tab cannot drift away from what actually shipped.
+    private struct Identity {
+        let version: String
+        let copyright: String
+        let repository: URL?
+        let issues: URL?
+
+        init(bundle: Bundle = .main) {
+            let info = bundle.infoDictionary ?? [:]
+            func string(_ key: String) -> String? { info[key] as? String }
+            func url(_ key: String) -> URL? { string(key).flatMap(URL.init(string:)) }
+
+            version = string("CFBundleShortVersionString") ?? "dev"
+            copyright = string("NSHumanReadableCopyright") ?? ""
+            repository = url("OSWRepositoryURL")
+            issues = url("OSWIssueTrackerURL")
+        }
     }
+
+    private let identity = Identity()
 
     var body: some View {
         VStack(spacing: 10) {
@@ -16,7 +35,7 @@ struct AboutView: View {
             Text("OpenSwitchr")
                 .font(.title2.weight(.semibold))
 
-            Text("Version \(version)")
+            Text("Version \(identity.version)")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -26,8 +45,23 @@ struct AboutView: View {
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 24)
 
-            Link("Source code", destination: URL(string: "https://github.com/trsdn/OpenSwitchr")!)
-                .font(.callout)
+            HStack(spacing: 16) {
+                if let repository = identity.repository {
+                    Link("Source code", destination: repository)
+                }
+                if let issues = identity.issues {
+                    Link("Report an issue", destination: issues)
+                }
+            }
+            .font(.callout)
+
+            if !identity.copyright.isEmpty {
+                Text(identity.copyright)
+                    .font(.caption2)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 16)
+            }
         }
         .padding(20)
     }

--- a/docs/self-assessment.md
+++ b/docs/self-assessment.md
@@ -98,13 +98,15 @@ what it reports. Values are not hand-maintained:
 | macOS 15+ | Hardcoded, but `scripts/check.sh` fails when it disagrees with `Package.swift` or `scripts/build-app.sh` |
 | CI | GitHub's first-party workflow badge for `main` |
 | Latest tag | The repository's tags |
-| Conformance | Read live from `.github/conformance.yml` |
+| Conformance | Rendered from `.github/conformance.yml` and committed as `.github/badges/conformance.svg`; the Conformance workflow fails when the two drift apart |
 
-What keeps this at `partial` is the image host. Four of the five are rendered by
-`img.shields.io`, and the standard asks for images served from the repository or
-a first-party source *where practical*, because a third-party image host
-observes every reader. Serving them from here would mean generating and
-committing SVGs, which runs into the same write-permission conflict as `P09`.
+What keeps this at `partial` is the image host. The conformance badge is served
+from this repository and the CI badge is first-party, but the licence, platform,
+and tag badges are rendered by `img.shields.io`, and the standard asks for
+images served from the repository or a first-party source *where practical*,
+because a third-party image host observes every reader. Serving those three
+from here would mean generating and committing more SVGs on a schedule, which
+runs into the same write-permission conflict as `P09`.
 
 The consequence is disclosed rather than hidden: the Privacy section of the
 README names `img.shields.io` as the one host that viewing the README contacts,

--- a/docs/self-assessment.md
+++ b/docs/self-assessment.md
@@ -1,0 +1,293 @@
+# Self-assessment
+
+Evidence for `.github/conformance.yml`. Assessed against version **1.5.1** of
+the [trsdn Repository Quality Standard](https://github.com/trsdn/.github/blob/main/docs/repository-quality-standard.md)
+on **2026-08-30**. Overall state: **Needs work** — two criteria fail, both for
+reasons named below, and the repository is otherwise usable and honest about
+itself.
+
+Every line here is evidence from the GitHub API, a workflow run, a measurement,
+or a file in the tree. Nothing is assumed. Where a result is `partial` or
+`fail`, the entry says what was observed and what would have to change.
+
+## What changed since the previous assessment
+
+The previous assessment was recorded inline in `AGENTS.md`, against standard
+version 1.3.3, and it had gone stale. It opened by reporting that the default
+branch held two files — `README.md` and `.gitignore` — with everything else
+living in an unmerged branch. That was true when it was written and stopped
+being true when pull request #1 merged, which invalidated roughly a dozen
+results at once, including the licence findings that it called the highest
+priority item in the repository.
+
+That failure is the reason `B13` exists and the reason this document is now
+separate from `AGENTS.md`: a fact with two homes has no home. It is also why
+the record is validated by a scheduled workflow rather than by memory.
+
+## Profiles
+
+| Profile | Applies | Why |
+| --- | --- | --- |
+| Baseline | Yes | Always |
+| Public | Yes | Public visibility |
+| Software | Yes | Ships a Swift package and an app bundle |
+| Product Identity | Yes | Builds a signed `.app` a user installs |
+| Package And Release | Yes | Releases run through the notarization broker |
+| Agent Readiness | Yes | `AGENTS.md` exists and agents work here |
+| Language And Localization | Yes | A shipping user interface |
+| Accessibility | Yes | A shipping user interface |
+| Data Protection And Privacy | Yes | Reads window metadata and captures screen content |
+| Deployable | No | Nothing is deployed to any environment |
+| Documentation | No | The product is software; docs support it |
+| Published Sites | No | There is no site. The homepage points at the releases page |
+| Archived | No | Actively developed |
+
+## Failures
+
+### `P09` — repository activity card
+
+**Fail, and deliberately so.** The criterion requires an activity card
+generated from an authoritative source and committed to the repository, so no
+third-party rendering service observes readers. The shared implementation is the
+reusable `repo-stats` workflow, which commits the rendered SVG back to the
+repository and therefore needs `contents: write`.
+
+`AGENTS.md` forbids exactly that: *"no workflow here may use a secret, an
+environment, or write permissions."* That rule is what makes this repository
+safe to build from without reviewing every workflow, and it is not worth trading
+for a statistics card.
+
+The two are genuinely in conflict, so this is recorded as a fail rather than
+argued into a pass. Resolving it needs either a generation path that does not
+write to the repository, or an explicit decision to relax the workflow rule.
+
+### `R05` — built artifacts smoke-tested in a clean environment
+
+**Fail.** `openswitchr-diag --probe-app` is a real end-to-end check — it posts a
+synthetic hotkey, times the overlay against a window-ID baseline, confirms focus
+moved by reading the CoreGraphics z-order, and hovers a Dock icon twice — but it
+runs against the app installed on the development machine, where the toolchain,
+the permissions, and the previously granted TCC entries all already exist.
+
+Nothing yet takes a notarized artifact, installs it somewhere that has never
+seen it, and confirms it launches and is trusted by Gatekeeper. The most likely
+failure that hides here is a signing or notarization problem, which is invisible
+locally by construction: the local machine trusts its own developer certificate.
+
+## Partials
+
+### `B13` — each fact has one home
+
+`README.md` and `AGENTS.md` still overlap. Both describe the shared-index
+architecture, both tell the `⌘-Tab` story, and both state the current-Space
+scope. The audiences differ — one is for a user deciding whether to install, the
+other for someone changing the code — but the same fact is written twice in
+places, and the two can drift.
+
+Moving the conformance assessment out of `AGENTS.md` removed the worst instance.
+The remaining overlap is smaller and has not yet caused a contradiction.
+
+### `P08` — status badges
+
+The required five badges are present, in the required order, and each links to
+what it reports. Values are not hand-maintained:
+
+| Badge | Where the value comes from |
+| --- | --- |
+| License | GitHub's own licence detection for this repository |
+| macOS 15+ | Hardcoded, but `scripts/check.sh` fails when it disagrees with `Package.swift` or `scripts/build-app.sh` |
+| CI | GitHub's first-party workflow badge for `main` |
+| Latest tag | The repository's tags |
+| Conformance | Read live from `.github/conformance.yml` |
+
+What keeps this at `partial` is the image host. Four of the five are rendered by
+`img.shields.io`, and the standard asks for images served from the repository or
+a first-party source *where practical*, because a third-party image host
+observes every reader. Serving them from here would mean generating and
+committing SVGs, which runs into the same write-permission conflict as `P09`.
+
+The consequence is disclosed rather than hidden: the Privacy section of the
+README names `img.shields.io` as the one host that viewing the README contacts,
+and states that nothing in the app itself contacts it.
+
+### `S02` — automated test coverage
+
+48 tests across 6 suites, all pure logic: the AX-to-`CGWindowID` linker
+including its tie-breaking and determinism, MRU ordering, the window matcher,
+the thumbnail refresh-rate age limits, permission-grant watching, and focus
+target resolution. They cover the parts where a subtle bug is invisible, and
+several encode a bug that actually shipped.
+
+They cannot cover anything that talks to another process or draws: accessibility
+enumeration, ScreenCaptureKit, the event tap, and every SwiftUI view. That gap
+is filled by `openswitchr-diag`, which is run by hand and is not in CI, because
+it needs the Accessibility permission and real windows. Three release-blocking
+bugs have gone through exactly that gap — the app never starting, settings that
+could not be changed, and a Dock hover that worked only the first time — while
+every test stayed green.
+
+### `S03` — automated static analysis
+
+`swift build -Xswiftc -warnings-as-errors` runs in CI on both runners, and this
+project has repeatedly found real bugs behind warnings, so that is genuine
+static analysis rather than a formality. Markdown is now linted in CI against
+the same `.markdownlint.jsonc` the standard publishes.
+
+No Swift formatter or linter is configured. There is no `swift-format`
+configuration and no SwiftLint, so formatting is consistent only by habit.
+
+### `R01` — package metadata
+
+`Info.plist` now carries the product name, both version strings, the repository
+URL, the issue tracker URL, the licence identifier, and the copyright holder,
+and `scripts/check.sh` asserts every one of those keys is present.
+
+`Package.swift` carries none of it, because SwiftPM has no field for a licence,
+a repository, or a description. That is a limitation of the manifest format
+rather than an omission, but the criterion asks for complete package metadata
+and half of it lives somewhere SwiftPM cannot see.
+
+### `R03` — a tag produces installable artifacts through automation
+
+Automation exists and is real: `trsdn/macos-notarization-broker` builds from a
+pinned commit, signs, and notarizes, without any Apple credential reaching this
+repository. That is a better arrangement than a release workflow here would be.
+
+It is not triggered by a tag. Someone runs `scripts/request.sh openswitchr
+v0.1.0` from a broker checkout. Pushing a tag therefore publishes nothing on its
+own, and a tag can exist with no artifact behind it — which is the state this
+repository is in right now.
+
+### `R04` — tag, package version, and release title agree
+
+`v0.1.0` is tagged and pushed, and points at the current `main`. `Info.plist`
+and `CHANGELOG.md` both say `0.1.0`, and `scripts/check.sh` now fails if those
+two ever disagree.
+
+No GitHub Release exists, so there is no release title to agree with anything,
+and the tag has no artifact attached. Two of the three things the criterion
+compares are present and consistent; the third has not been created.
+
+### `R06` — release notes
+
+`CHANGELOG.md` follows Keep a Changelog, states the versioning policy, and its
+entries describe the measurement or the trap behind each change rather than
+listing files. It is materially better than most release notes.
+
+It has never been published as release notes, because no release exists.
+
+### `I06` — identity metadata produced by the build
+
+Still hand-maintained. `CFBundleVersion` and `CFBundleShortVersionString` are
+typed into `Info.plist`; nothing derives them from the tag.
+
+What changed is that drift is now loud rather than silent: `scripts/check.sh`
+fails when the two plist versions disagree with each other or with the newest
+release heading in `CHANGELOG.md`, and CI runs that check on both runners. The
+standard accepts a check that fails on drift in place of derivation for badge
+values, which is why this is a `partial` rather than a `fail`.
+
+Deriving the version properly means changing how the bundle is produced, and
+the release bundle is assembled by the broker's `openswitchr-swiftpm` adapter
+rather than by `scripts/build-app.sh`. Doing it in only one of the two would
+make them disagree, so this needs a broker-side change first.
+
+### `X01` — keyboard operability
+
+The switcher overlay is fully keyboard-driven: hold the modifier, `Tab` and
+`⇧-Tab` move the selection, typing filters by app name or window title, `Escape`
+cancels, releasing the modifier commits. The selection is visibly indicated.
+
+Dock hover previews have no keyboard route at all. They are triggered by the
+pointer entering a Dock icon, which is inherent to the gesture rather than an
+oversight — but it does mean one of the two frontends is pointer-only. The
+switcher reaches every window on the current Space without a pointer, so nothing
+is unreachable; it is the Dock-adjacent workflow specifically that is not.
+
+This is now stated in the Accessibility section of the README rather than left
+for a user to discover.
+
+### `X03` — contrast, text sizing, and colour
+
+Meaning never rests on colour alone. The quit control on a preview tile is red
+*and* a distinct glyph placed in the opposite corner from the close control, and
+a minimized window is dimmed *and* explicitly marked.
+
+Behaviour under enlarged platform text sizes is unverified. Tiles size
+themselves from the preview-size preference rather than from text metrics, so a
+large accessibility text size may clip a long window title. Reduced-motion and
+increased-contrast settings are not specifically honoured either; the panels use
+system materials and standard SwiftUI controls and inherit whatever those do.
+Both limitations are stated in the README under `X05`.
+
+## Results that are `na`, and why
+
+- **`D01`–`D06`** — nothing is deployed. There is no environment, no runtime
+  infrastructure, and no operational surface. The app runs on a user's machine.
+- **`T01`–`T05`** — the product is an application, not documentation. The
+  documentation here supports the software rather than being the deliverable.
+- **`W01`–`W08`** — there is no published site. The repository homepage points
+  at its own releases page, which is not a site in the sense the profile means.
+- **`S06`** — there is no runtime configuration. No environment variable, no
+  configuration file, no remote configuration; only user preferences in
+  `UserDefaults`, which are the user's own data rather than deployment config.
+- **`L04`, `L06`** — there are no string catalogs and no translations, so there
+  is nothing to keep complete or to trace. English-only is declared under `L03`.
+- **`L05`** — the interface formats no dates, numbers, currency, or sorted
+  lists. The only numerals a user sees are in fixed option labels such as
+  "At most every 5 s", which are static strings rather than formatted values,
+  so there is no locale-sensitive formatting to get right or wrong.
+- **`A01`–`A04`** — actively developed, not archived.
+
+## Notable passes
+
+These are recorded because they took work, not because they were free.
+
+- **`B06`, `S09`** — `main` is protected by a ruleset: pull requests are
+  required, the two CI matrix checks and the secret scan must pass, and force
+  pushes and branch deletion are blocked. Verified against the rulesets API.
+- **`S05`** — three independent layers. `secret-scan.yml` runs on every push and
+  pull request, GitHub secret scanning is enabled, and push protection now
+  rejects a credential before it reaches the remote.
+- **`S07`** — verified by reading every logging call in the tree: no window
+  title, no personal data, only counts, pids, and error descriptions. This is
+  what makes it safe to ask a reporter to paste a log into an issue, which the
+  bug report form does.
+- **`S10`** — `AGENTS.md` records not just the architecture but the traps that
+  produced it, including two long detours caused by a broken measurement rather
+  than broken code.
+- **`G03`, `G06`, `G07`** — forbidden operations, generated paths, and the
+  review expectation are now written down. Previously an agent was expected to
+  follow rules it had no way to read.
+- **`G05`** — `scripts/check.sh` is one command that validates a change without
+  a signing identity, permissions, or network access.
+- **`I02`, `I03`, `I04`** — the bundle carries its repository URL, issue tracker
+  URL, licence identifier, and copyright holder, ships the licence text in
+  `Contents/Resources`, and the About tab renders its links by reading those
+  keys back rather than hardcoding them a second time.
+- **`X04`** — `openswitchr-diag` emits plain text with no colour and no Unicode
+  decoration, so its output survives any pipe, log, or screen reader.
+- **`Y02`–`Y06`** — the app opens no network connection, has no telemetry, sends
+  nothing to any third party or AI provider, keeps thumbnails in memory under a
+  byte budget so nothing outlives the session, and stores only preferences,
+  whose location and deletion command are documented. `Y01` is the load-bearing
+  one: the README states the "none" case explicitly, because "no privacy policy"
+  and "no data collection" look identical from the outside.
+
+## What to do next
+
+In order of how much each one moves:
+
+1. **Publish a GitHub Release for `v0.1.0`** with a notarized artifact from the
+   broker. That is the single change that most improves the release profile,
+   moving `R04` and `R06` and making `R05` testable at all.
+2. **Smoke-test that artifact somewhere clean** — a machine or VM that has never
+   run OpenSwitchr — and record the result. Clears `R05`.
+3. **Decide the `P09` conflict deliberately**: either accept no activity card,
+   or relax the no-write-permissions rule with a stated reason. Either is a
+   defensible answer; leaving it undecided is not.
+4. **Add a Swift formatter or linter** to close `S03`.
+5. **Verify the app under enlarged accessibility text sizes** and either fix the
+   clipping or keep the limitation documented. Moves `X03`.
+6. **Resolve the version derivation** with the broker so `I06` stops depending
+   on a human typing the same number in two files.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -66,6 +66,10 @@ mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
 cp "$BUILD_DIR/OpenSwitchr" "$APP/Contents/MacOS/OpenSwitchr"
 cp "$PROJECT_DIR/Info.plist" "$APP/Contents/Info.plist"
 
+# The licence travels with the artifact, not just with the repository: someone
+# handed a .app has no checkout to read it from.
+cp "$PROJECT_DIR/LICENSE" "$APP/Contents/Resources/LICENSE"
+
 HAS_ICON=false
 if [[ -f "$PROJECT_DIR/Resources/AppIcon.icns" ]]; then
     cp "$PROJECT_DIR/Resources/AppIcon.icns" "$APP/Contents/Resources/AppIcon.icns"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# The one command that validates a change before it is proposed.
+#
+# Everything here runs without a signing identity, without the Accessibility
+# permission, and without a network connection, so it works the same on a
+# laptop, in CI, and for an agent. The checks that *do* need real windows live
+# in `openswitchr-diag` and are deliberately not run from here — see the
+# "Verifying the app, not just the core" section of AGENTS.md.
+#
+#   bash scripts/check.sh
+#   bash scripts/check.sh --metadata-only   # skip build and tests
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+RUN_BUILD=true
+case "${1:-}" in
+    --metadata-only) RUN_BUILD=false ;;
+    "") ;;
+    *) echo "usage: $0 [--metadata-only]" >&2; exit 2 ;;
+esac
+
+failures=0
+
+step() {
+    printf '\n== %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+if [[ "$RUN_BUILD" == true ]]; then
+    # Warnings are treated as failures: this project has repeatedly found real
+    # bugs behind warnings, so a warning is a finding, not noise.
+    step "Build (warnings are errors)"
+    if swift build -Xswiftc -warnings-as-errors; then
+        echo "ok"
+    else
+        fail "swift build"
+    fi
+
+    step "Tests"
+    if swift test; then
+        echo "ok"
+    else
+        fail "swift test"
+    fi
+fi
+
+# A version typed into Info.plist by hand drifts away from the changelog and
+# from the tag without anything noticing. This does not fix that, but it does
+# make the drift loud. See criterion I06 in .github/conformance.yml.
+step "Version consistency"
+plist_short="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' Info.plist 2>/dev/null || echo '')"
+plist_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' Info.plist 2>/dev/null || echo '')"
+changelog_version="$(sed -n 's/^## \[\([0-9][^]]*\)\].*/\1/p' CHANGELOG.md | head -1)"
+
+echo "Info.plist CFBundleShortVersionString: ${plist_short:-<missing>}"
+echo "Info.plist CFBundleVersion:            ${plist_build:-<missing>}"
+echo "CHANGELOG.md newest release:           ${changelog_version:-<missing>}"
+
+if [[ -z "$plist_short" || -z "$plist_build" || -z "$changelog_version" ]]; then
+    fail "could not read all three version strings"
+elif [[ "$plist_short" != "$plist_build" ]]; then
+    fail "Info.plist disagrees with itself: $plist_short vs $plist_build"
+elif [[ "$plist_short" != "$changelog_version" ]]; then
+    fail "Info.plist says $plist_short, CHANGELOG.md says $changelog_version"
+else
+    echo "ok"
+fi
+
+# Identity keys the About tab reads back at runtime. A missing key degrades
+# silently into a hidden link, which is exactly the kind of failure that ships.
+step "Bundle identity keys"
+for key in CFBundleName CFBundleIdentifier NSHumanReadableCopyright \
+           OSWLicenseIdentifier OSWRepositoryURL OSWIssueTrackerURL; do
+    if /usr/libexec/PlistBuddy -c "Print :$key" Info.plist >/dev/null 2>&1; then
+        echo "ok   $key"
+    else
+        fail "Info.plist is missing $key"
+    fi
+done
+
+# The minimum macOS version is stated in three places that no compiler compares:
+# the package manifest, the bundle the build script writes, and the README badge
+# a reader believes. A hardcoded badge beside a manifest that has moved on is
+# precisely the drift the badge convention exists to prevent.
+step "Minimum macOS version agrees everywhere"
+manifest_major="$(sed -n 's/.*\.macOS(\.v\([0-9][0-9]*\)).*/\1/p' Package.swift | head -1)"
+bundle_major="$(sed -n "s/.*LSMinimumSystemVersion'\] = '\([0-9][0-9]*\)\..*/\1/p" scripts/build-app.sh | head -1)"
+badge_major="$(sed -n 's/.*img\.shields\.io\/badge\/macOS-\([0-9][0-9]*\)%2B.*/\1/p' README.md | head -1)"
+
+echo "Package.swift platforms:               ${manifest_major:-<missing>}"
+echo "build-app.sh LSMinimumSystemVersion:   ${bundle_major:-<missing>}"
+echo "README badge:                          ${badge_major:-<missing>}"
+
+if [[ -z "$manifest_major" || -z "$bundle_major" || -z "$badge_major" ]]; then
+    fail "could not read the minimum macOS version from all three places"
+elif [[ "$manifest_major" != "$bundle_major" || "$manifest_major" != "$badge_major" ]]; then
+    fail "minimum macOS version disagrees: manifest $manifest_major, bundle $bundle_major, badge $badge_major"
+else
+    echo "ok"
+fi
+
+# Documentation in this repository carries design rationale, so it is linted
+# too. Skipped rather than failed when npx is unavailable, because the check
+# must stay runnable offline. CI runs the same linter in its own workflow.
+if [[ "$RUN_BUILD" == true ]]; then
+    step "Markdown lint"
+    if command -v npx >/dev/null 2>&1; then
+        if npx --yes markdownlint-cli2@0.18.1 "**/*.md"; then
+            echo "ok"
+        else
+            fail "markdownlint"
+        fi
+    else
+        echo "skipped: npx not available"
+    fi
+fi
+
+printf '\n'
+if (( failures > 0 )); then
+    echo "$failures check(s) failed." >&2
+    exit 1
+fi
+
+echo "All checks passed."
+
+if [[ "$RUN_BUILD" == true ]]; then
+    echo
+    echo "Not covered here, because no test can reach it: real accessibility"
+    echo "linking rates, capture timings, and whether the installed app wired any"
+    echo "of it up. Run 'swift run openswitchr-diag --bench --capture' and"
+    echo "'swift run openswitchr-diag --probe-app' from a terminal that holds the"
+    echo "Accessibility permission."
+fi


### PR DESCRIPTION
The repository quality assessment that lived inline in `AGENTS.md` had gone
stale. It opened by reporting a default branch holding two files — `README.md`
and `.gitignore` — with everything else in an unmerged branch, and derived its
highest-priority finding, "no licence on the default branch", from that. #1
merged and invalidated roughly a dozen results at once, and nothing noticed,
because the result had no home of its own. It also assessed against standard
version 1.3.3; the standard is now at 1.5.1, with criteria the old assessment
never saw.

That is exactly the failure `B13` exists to prevent, so the record moves out of
prose.

## What this changes

**The assessment now has one home, and it is checked.**
`.github/conformance.yml` holds a result for all 93 criteria; the reasoning for
every non-pass is in `docs/self-assessment.md`. A scheduled workflow validates
the record against the published catalog, so an incomplete record, a retired
criterion, or an assessment that ages past the review cadence turns a check red
without anyone remembering to look. `AGENTS.md` now points at both instead of
restating them.

**One command validates a change.** `scripts/check.sh` builds with warnings as
errors, runs the tests, lints the markdown, and checks the bundle metadata. It
needs no signing identity, no permissions, and no network, so it behaves
identically on a laptop, in CI, and for an agent. CI calls the same script with
`--metadata-only` rather than keeping a second copy of the logic.

**Three facts that nothing compared now fail loudly when they drift:**

| Fact | Was maintained in | Now asserted against |
| --- | --- | --- |
| Version | `Info.plist`, by hand | newest release heading in `CHANGELOG.md` |
| Minimum macOS | `Package.swift` | `scripts/build-app.sh` and the README badge |
| Identity keys | nowhere | presence of all six required `Info.plist` keys |

**Product identity reaches the artifact.** The bundle carries its repository
URL, issue tracker URL, licence identifier, and copyright holder, and ships the
licence text in `Contents/Resources`. `AboutView` reads those keys back out of
the bundle rather than hardcoding the same links a second time, so what shipped
and what the user sees cannot disagree.

**`AGENTS.md` gains the sections an agent was expected to obey but could not
read**: forbidden and high-risk operations (Apple credentials, workflow write
permissions, history rewriting, moving a pushed tag, weakening the signing
check), generated and machine-owned paths, and the review expectation for
agent-authored changes. `Resources/AppIcon.icns` is marked `linguist-generated`
in a new `.gitattributes` — every build rewrites it, so hand-editing it
accomplishes nothing.

**The README states the "none" cases**, which previously only existed as an
absence: nothing collected, no outbound connection, no telemetry, no third
party; preferences in `UserDefaults` under `com.openswitchr.app` with the
command to delete them; English-only; and the known accessibility limits — Dock
hover previews are pointer-only, and behaviour under enlarged text sizes is
unverified. Plus the required badge block, a configuration section, and a
support section.

**Housekeeping**: issue forms for bugs and proposals, `CODEOWNERS`, Dependabot
for the pinned action versions, `.github/github-app.yml`, and a markdown lint
workflow. The two sibling `### Added` headings under `0.1.0` in the changelog
are merged, which was both a lint failure and genuinely confusing to read.

## Repository settings changed alongside this

These are why `B06`, `S05`, and `S09` are recorded as passing, and they are not
visible in the diff:

- `main` requires a pull request and the three CI checks, and blocks force
  pushes and branch deletion.
- Secret scanning, push protection, Dependabot security updates, and private
  vulnerability reporting are enabled.
- Topics including `trsdn-standard`, and a homepage, are set.

Secret scanning validity checks and non-provider patterns would not enable on
this plan; they are not required by `S05`.

## Two criteria are recorded as failing

Rather than argued into a pass:

- **`P09`** wants a repository activity card generated from an authoritative
  source and committed. The shared implementation needs a workflow with
  `contents: write`, and `AGENTS.md` forbids any workflow here from using a
  secret, an environment, or write permissions. That rule is worth more than a
  statistics card, so the conflict is recorded and left for a deliberate
  decision.
- **`R05`** wants a built artifact smoke-tested in a clean environment. No
  release exists yet, and `--probe-app` runs against the app installed on the
  development machine, which already trusts its own certificate.

Result: **53 pass, 11 partial, 2 fail, 27 n/a** — state `Needs work`.

## Verification

- `bash scripts/check.sh` — 48 tests in 6 suites, build clean with
  warnings-as-errors, 0 markdown lint errors, all metadata checks pass.
- `bash scripts/build-app.sh` — produced a signed bundle; confirmed the new
  `Info.plist` keys and `Contents/Resources/LICENSE` are present, and that the
  regenerated `AppIcon.icns` is byte-identical to the tracked one.
- Conformance record cross-checked against the 1.5.1 catalog: 93 of 93
  criteria present, none extra, no result outside the vocabulary.

**Not verified.** The About tab's new "Report an issue" link has not been
clicked by a human. Per the constraint in `AGENTS.md`, a control in these panels
is unverified until someone clicks it, and I am not going to imply otherwise.
